### PR TITLE
[Issue #373] Feature WhatsApp Share

### DIFF
--- a/client/components/share/index.js
+++ b/client/components/share/index.js
@@ -1,3 +1,4 @@
 export { default as FacebookShareButton } from './facebook-share-button'
 export { default as TwitterShareButton } from './twitter-share-button'
+export { default as WhatsAppShareButton } from './whatsapp-share-button'
 export { default as TellAFriend } from './tell-a-friend'

--- a/client/components/share/tell-a-friend.js
+++ b/client/components/share/tell-a-friend.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react'
 
-import { FacebookShareButton, TwitterShareButton } from '~components/share'
+import { FacebookShareButton, TwitterShareButton, WhatsAppShareButton } from '~components/share'
 
 const TellAFriend = ({ href, message, mobilization, imageUrl, imageWidth }) => (
   <div className='center p3 bg-white darkengray rounded'>
@@ -11,6 +11,7 @@ const TellAFriend = ({ href, message, mobilization, imageUrl, imageWidth }) => (
     <p>Agora, compartilhe com seus amigos!</p>
     <p><FacebookShareButton href={href} /></p>
     <p><TwitterShareButton href={href} text={mobilization.twitter_share_text} /></p>
+    <p><WhatsAppShareButton href={href} /></p>
   </div>
 )
 

--- a/client/components/share/whatsapp-share-button.js
+++ b/client/components/share/whatsapp-share-button.js
@@ -1,0 +1,19 @@
+import React, { PropTypes } from 'react'
+
+const WhatsAppShareButton = ({ href, mobilization }) => {
+  return (
+    <a
+      className='btn white h3 p3 col-12 caps h5 rounded'
+      href={`whatsapp://send?text=${href}`}
+      style={{ backgroundColor: '#4CEC68', color: '#fff' }}
+    >
+      Compartilhar no WhatsApp
+    </a>
+  )
+}
+
+WhatsAppShareButton.propTypes = {
+  href: PropTypes.string.isRequired
+}
+
+export default WhatsAppShareButton

--- a/client/mobilizations/widgets/__plugins__/form/action-creators/async-form-entry-create.js
+++ b/client/mobilizations/widgets/__plugins__/form/action-creators/async-form-entry-create.js
@@ -1,7 +1,7 @@
 // Parent module dependencies
 import AnalyticsEvents from '~mobilizations/widgets/utils/analytics-events'
 import * as WidgetSelectors from '~mobilizations/widgets/selectors'
-import { actions as WidgetActions } from '~mobilizations/widgets'
+import * as WidgetActions from '~mobilizations/widgets/action-creators'
 
 // Current module dependencies
 import * as t from '../action-types'

--- a/test/client/unit/components/share/whatsapp-share-button.spec.js
+++ b/test/client/unit/components/share/whatsapp-share-button.spec.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+
+import { WhatsAppShareButton } from '~components/share'
+
+describe('client/components/share/whatsapp-share-button', () => {
+  let wrapper
+  const props = {
+    href: 'http://www.minhasampa.org.br'
+  }
+
+  describe('#render', () => {
+    beforeAll(() => {
+      wrapper = shallow(<WhatsAppShareButton {...props} />)
+    })
+
+    it('should render an <a /> tag element', () => {
+      expect(wrapper.find('a')).to.have.length(1)
+    })
+    it('should render an <a /> tag element with href containing whatsapp share link', () => {
+      expect(wrapper.find('a').props().href).to.be.equal(`whatsapp://send?text=${props.href}`)
+    })
+  })
+})


### PR DESCRIPTION
# Issue reference
Add share with whatsapp in TellFriend #373

# How to test
- Mock `authenticate/redux/reducer.js` initialState:
```js
const initialState = {
  user: { email: '(_____)', first_name: '(_____)' },
  credentials: {
    'access-token': '(_____)',
    'token-type': '(_____)',
    'client': '(_____)',
    'expiry': '(_____)',
    'uid': '(_____)'
  }
}
```

**Tip:** Use the following command line to get headers that needs to be mocked:
```bash
curl -v \
    -X POST \
    -H 'Content-Type: application/json' \
    -d '{ "email": "$email", "password": "$password" }' \
    http://localhost:3000/auth/sign_in
```

- Access a mobilization by public view like https://www.minhasampa.org.br, subscribe into a form, make a pressure or a donation and you will see the _post-action_ action buttons including the **WhatsApp** share button in **SS01**

- Click on the **WhatsApp** share button, choose a person to share the mobilization and the result must be like in the **SS02**
    - **To get the mobilization's link renders the mobilization image and description, ensure the Facebook Sharing data in the mobilization settings are filled properly. Wait a sec, after choose a person to share and, the preview link will renders properly**

**ScreenShots**

| **SS01**                                                                                                                            | **SS02**                                                                                                                            |
|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| ![screenshot_20170306-120052](https://cloud.githubusercontent.com/assets/5435389/23619229/cf5bd020-0271-11e7-9009-41d402639ca9.png) | ![screenshot_20170306-124956](https://cloud.githubusercontent.com/assets/5435389/23619359/2feb8138-0272-11e7-8b7c-98861091bf9c.png) |