### PR TITLE
[Issue #375] Feature Zendesk Widget

### DIFF
--- a/client/components/external-services/index.js
+++ b/client/components/external-services/index.js
@@ -1,0 +1,1 @@
+export { default as ZendeskWidget } from './zendesk-widget'

--- a/client/components/external-services/zendesk-widget.js
+++ b/client/components/external-services/zendesk-widget.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+const ZendeskWidget = () => (
+  <script dangerouslySetInnerHTML={{__html: `
+window.zEmbed||function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");
+window.zEmbed=function(){a.push(arguments)},window.zE=window.zE||window.zEmbed,
+r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style
+.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode
+.insertBefore(r,d),i=r.contentWindow,s=i.document;try{o=s}catch(e){n=document.domain,r
+.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}o.open()._l=function(){
+var o=this.createElement("script");n&&(this.domain=n),o.id="js-iframe-async",o.src=e,
+this.t=+new Date,this.zendeskHost=t,this.zEQueue=a,this.body.appendChild(o)},o.write(
+'<body onload="document._l();">'),o.close()}(
+"https://assets.zendesk.com/embeddable_framework/main.js","nossas.zendesk.com")
+  `}} />
+)
+
+export default ZendeskWidget

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "coverage": "nyc npm test",
     "start": "cross-env NODE_ENV=development ./node_modules/.bin/nodemon -r 'babel-register' --watch ./server --watch ./tools ./server",
     "build": "./node_modules/.bin/webpack -p --config ./tools/webpack.client.prod.js && ./node_modules/.bin/webpack -p --config ./tools/webpack.server.prod.js",
-    "clean": "rm -rf build"
+    "clean": "rm -rf build",
+    "routes": "grep -rhe path: ./routes/$inner | sed -e \"s/path: '\\([a-zA-Z\\/:_]*\\)',/\\1/g\" | sort | uniq"
   },
   "repository": {
     "type": "git",

--- a/routes/logged-in/background/container.js
+++ b/routes/logged-in/background/container.js
@@ -1,11 +1,15 @@
 import React, { PropTypes } from 'react'
 
 import { Background } from '~client/components/layout'
+import { ZendeskWidget } from '~components/external-services'
 
 const BackgroundContainer = ({ children }) => (
-  <Background image={process.env.BROWSER ? require('~client/images/bg-login.png') : ''}>
-    {children}
-  </Background>
+  <div>
+    <ZendeskWidget />
+    <Background image={process.env.BROWSER ? require('~client/images/bg-login.png') : ''}>
+      {children}
+    </Background>
+  </div>
 )
 
 BackgroundContainer.propTypes = {

--- a/routes/logged-in/sidebar/container.js
+++ b/routes/logged-in/sidebar/container.js
@@ -2,12 +2,16 @@ import React, { PropTypes } from 'react'
 
 import { Loading } from '~components/await'
 import Sidebar from '~components/navigation/sidebar/sidebar'
+import { ZendeskWidget } from '~components/external-services'
 
 const ApplicationContainer = ({ children, loading, sidebarProps }) => {
   return loading ? <Loading /> : (
-    <Sidebar {...sidebarProps}>
-      {children && React.cloneElement(children)}
-    </Sidebar>
+    <div>
+      <ZendeskWidget />
+      <Sidebar {...sidebarProps}>
+        {children && React.cloneElement(children)}
+      </Sidebar>
+    </div>
   )
 }
 

--- a/test/client/unit/components/external-issues/zendesk-widget.spec.js
+++ b/test/client/unit/components/external-issues/zendesk-widget.spec.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { expect } from 'chai'
+
+import { ZendeskWidget } from '~components/external-services'
+
+describe('client/components/external-services/zendesk-widget', () => {
+  const wrapper = shallow(<ZendeskWidget />)
+
+  describe('#render', () => {
+    it('should render without crash', () => {
+      expect(wrapper).to.be.ok
+    })
+
+    it('should render root <script /> tag element', () => {
+      expect(wrapper.find('script')).to.have.length(1)
+    })
+  })
+})

--- a/test/routes/unit/logged-in/background/container.spec.js
+++ b/test/routes/unit/logged-in/background/container.spec.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+
+import BackgroundContainer from '~routes/logged-in/background/container'
+
+describe('routes/application/container', () => {
+  let wrapper = shallow(
+    <BackgroundContainer>
+      <h1>Foo Bar</h1>
+    </BackgroundContainer>
+  )
+
+  it('render without crashed', () => {
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render a zendesk widget component', () => {
+    expect(wrapper.find('ZendeskWidget')).to.have.length(1)
+  })
+})

--- a/test/routes/unit/logged-in/sidebar/container.spec.js
+++ b/test/routes/unit/logged-in/sidebar/container.spec.js
@@ -41,4 +41,9 @@ describe('routes/application/container', () => {
     const { wrapper } = setup()
     expect(wrapper.find('Sidebar').length).to.equal(1)
   })
+
+  it('should render a zendesk widget component', () => {
+    const { wrapper } = setup()
+    expect(wrapper.find('ZendeskWidget')).to.have.length(1)
+  })
 })


### PR DESCRIPTION
# Issue reference
Add zendesk widget to easily receive feedback from users when at dashboard #375

# How to test
- Mock `authenticate/redux/reducer.js` initialState:
```js
const initialState = {
  user: { email: '(_____)', first_name: '(_____)' },
  credentials: {
    'access-token': '(_____)',
    'token-type': '(_____)',
    'client': '(_____)',
    'expiry': '(_____)',
    'uid': '(_____)'
  }
}
```

**Tip:** Use the following command line to get headers that needs to be mocked:
```bash
curl -v \
    -X POST \
    -H 'Content-Type: application/json' \
    -d '{ "email": "$email", "password": "$password" }' \
    http://localhost:3000/auth/sign_in
```

- Access one of the logged-in routes (command: `inner=logged-in yarn routes`) and **zendesk widget** must be render on bottom right corner of the page following SS below:

<img width="177" alt="screen shot 2017-03-06 at 19 43 33" src="https://cloud.githubusercontent.com/assets/5435389/23633625/3a9d0722-02a5-11e7-943a-02c27609da96.png">
