### PR TITLE
[Issue #364] Feature small layout fixes

### DIFF
--- a/client/mobilizations/widgets/__plugins__/content/components/editor-new/index.js
+++ b/client/mobilizations/widgets/__plugins__/content/components/editor-new/index.js
@@ -63,7 +63,7 @@ class EditorNew extends React.Component {
     }
 
     return (
-      <div className='widget editor-new link' style={{ fontFamily: bodyFont }}>
+      <div className='widget editor-new' style={{ fontFamily: bodyFont }}>
         <Editor
           value={value}
           theme={theme}

--- a/client/mobilizations/widgets/__plugins__/content/components/editor-old.js
+++ b/client/mobilizations/widgets/__plugins__/content/components/editor-old.js
@@ -135,7 +135,7 @@ class EditorOld extends React.Component {
             onClick={::this.handleOverlayClick}
           />
         </div>
-        <div className={classnames('link relative', editing ? 'z6' : 'z0')}>
+        <div className={classnames('relative', editing ? 'z6' : 'z0')}>
           <div
             className={classnames('widget', `${headerFont}-header`, `${bodyFont}-body`)}
             dangerouslySetInnerHTML={{__html: this.state.content}}


### PR DESCRIPTION
# Issue reference
Remove extra margin on images and bold in default link style #364

# How to test
- Mock `authenticate/redux/reducer.js` initialState:
```js
const initialState = {
  user: { email: '(_____)', first_name: '(_____)' },
  credentials: {
    'access-token': '(_____)',
    'token-type': '(_____)',
    'client': '(_____)',
    'expiry': '(_____)',
    'uid': '(_____)'
  }
}
```

**Tip:** Use the following command line to get headers that needs to be mocked:
```bash
curl -v \
    -X POST \
    -H 'Content-Type: application/json' \
    -d '{ "email": "$email", "password": "$password" }' \
    http://localhost:3000/auth/sign_in
```

- Check the images animated underline like SSs below:

| Current                                                                                                                                                               | Fix                                                                                                                                                                   |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="363" alt="screen shot 2017-03-06 at 22 44 08" src="https://cloud.githubusercontent.com/assets/5435389/23638577/3225dfee-02c1-11e7-8547-9b284dd9dc55.png"> | <img width="389" alt="screen shot 2017-03-06 at 22 37 47" src="https://cloud.githubusercontent.com/assets/5435389/23638530/f67d454a-02c0-11e7-8595-48e0526dc7f6.png"> | 

- Check the links bold like SSs below:

| Current                                                                                                                                                               | Fix                                                                                                                                                                   |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="180" alt="screen shot 2017-03-06 at 22 54 44" src="https://cloud.githubusercontent.com/assets/5435389/23638610/6af28318-02c1-11e7-91f3-cf8e2d401674.png"> | <img width="171" alt="screen shot 2017-03-06 at 22 56 46" src="https://cloud.githubusercontent.com/assets/5435389/23638617/780b05d4-02c1-11e7-8999-ac5ede850433.png"> | 