### PR TITLE
Feature custom whatsapp share text

### DIFF
--- a/client/components/share/tell-a-friend.js
+++ b/client/components/share/tell-a-friend.js
@@ -2,7 +2,15 @@ import React, { PropTypes } from 'react'
 
 import { FacebookShareButton, TwitterShareButton, WhatsAppShareButton } from '~components/share'
 
-const TellAFriend = ({ preview, href, message, mobilization, imageUrl, imageWidth }) => (
+const TellAFriend = ({
+  preview,
+  href,
+  message,
+  mobilization: { twitter_share_text: twitterShareText },
+  imageUrl,
+  imageWidth,
+  widget: { settings: { whatsapp_text: whatsappText } }
+}) => (
   <div className='center p3 bg-white darkengray rounded'>
     <div className='m0 h3 bold'>{message}</div>
     <div className='py2'>
@@ -10,14 +18,21 @@ const TellAFriend = ({ preview, href, message, mobilization, imageUrl, imageWidt
     </div>
     <p>Agora, compartilhe com seus amigos!</p>
     <p><FacebookShareButton href={href} /></p>
-    <p><TwitterShareButton href={href} text={mobilization.twitter_share_text} /></p>
-    <p><WhatsAppShareButton href={href} preview={preview} /></p>
+    <p><TwitterShareButton href={href} text={twitterShareText} /></p>
+    <p><WhatsAppShareButton whatsappText={whatsappText || href} preview={preview} /></p>
   </div>
 )
 
 TellAFriend.propTypes = {
   preview: PropTypes.bool,
-  mobilization: PropTypes.object.isRequired,
+  mobilization: PropTypes.shape({
+    twitter_share_text: PropTypes.string
+  }).isRequired,
+  widget: PropTypes.shape({
+    settings: PropTypes.shape({
+      whatsapp_text: PropTypes.string
+    })
+  }).isRequired,
   message: PropTypes.string.isRequired,
   href: PropTypes.string.isRequired,
   imageUrl: PropTypes.string,

--- a/client/components/share/whatsapp-share-button.js
+++ b/client/components/share/whatsapp-share-button.js
@@ -4,7 +4,10 @@ import classnames from 'classnames'
 const WhatsAppShareButton = ({ preview, whatsappText, mobilization }) => {
   return (
     <a
-      className={classnames('btn white h3 p3 col-12 caps h5 rounded', { 'lg-hide': !preview })}
+      className={classnames(
+        'btn white h3 p3 col-12 caps h5 rounded border-box',
+        { 'lg-hide': !preview }
+      )}
       href={`whatsapp://send?text=${encodeURIComponent(whatsappText)}`}
       style={{ backgroundColor: '#4CEC68', color: '#fff' }}
     >

--- a/client/components/share/whatsapp-share-button.js
+++ b/client/components/share/whatsapp-share-button.js
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react'
 import classnames from 'classnames'
 
-const WhatsAppShareButton = ({ preview, href, mobilization }) => {
+const WhatsAppShareButton = ({ preview, whatsappText, mobilization }) => {
   return (
     <a
       className={classnames('btn white h3 p3 col-12 caps h5 rounded', { 'lg-hide': !preview })}
-      href={`whatsapp://send?text=${href}`}
+      href={`whatsapp://send?text=${encodeURIComponent(whatsappText)}`}
       style={{ backgroundColor: '#4CEC68', color: '#fff' }}
     >
       Compartilhar no WhatsApp
@@ -15,7 +15,8 @@ const WhatsAppShareButton = ({ preview, href, mobilization }) => {
 
 WhatsAppShareButton.propTypes = {
   href: PropTypes.string.isRequired,
-  preview: PropTypes.bool
+  preview: PropTypes.bool,
+  whatsappText: PropTypes.string
 }
 
 export default WhatsAppShareButton

--- a/client/mobilizations/widgets/__plugins__/donation/components/__donation__/index.js
+++ b/client/mobilizations/widgets/__plugins__/donation/components/__donation__/index.js
@@ -262,7 +262,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     return finishMessageType === 'custom' ? (
       <FinishMessageCustom widget={widget} />
     ) : (
-      <DonationTellAFriend mobilization={mobilization} />
+      <DonationTellAFriend mobilization={mobilization} widget={widget} />
     )
   }
 

--- a/client/mobilizations/widgets/__plugins__/donation/components/donation-tell-a-friend.js
+++ b/client/mobilizations/widgets/__plugins__/donation/components/donation-tell-a-friend.js
@@ -4,11 +4,12 @@ import React, { PropTypes } from 'react'
 import * as paths from '~client/paths'
 import { TellAFriend } from '~components/share'
 
-const DonationTellAFriend = ({ preview, mobilization }) => {
+const DonationTellAFriend = ({ preview, mobilization, widget }) => {
   return (
     <TellAFriend
       preview={preview}
       mobilization={mobilization}
+      widget={widget}
       message={'Oba, doação registrada! Sua doação é via boleto? Verifique seu email.'}
       href={paths.mobilization(mobilization)}
     />
@@ -17,7 +18,8 @@ const DonationTellAFriend = ({ preview, mobilization }) => {
 
 DonationTellAFriend.propTypes = {
   preview: PropTypes.bool,
-  mobilization: PropTypes.object.isRequired
+  mobilization: PropTypes.object.isRequired,
+  widget: PropTypes.object.isRequired
 }
 
 export default DonationTellAFriend

--- a/client/mobilizations/widgets/__plugins__/form/components/__form__.js
+++ b/client/mobilizations/widgets/__plugins__/form/components/__form__.js
@@ -183,7 +183,7 @@ class Form extends Component {
       return finishMessageType === 'custom' ? (
         <FinishMessageCustom widget={widget} />
       ) : (
-        <FormTellAFriend mobilization={mobilization} />
+        <FormTellAFriend mobilization={mobilization} widget={widget} />
       )
     } else {
       return <p className='center p2 bg-darken-3'>{message}</p>

--- a/client/mobilizations/widgets/__plugins__/form/components/form-tell-a-friend.js
+++ b/client/mobilizations/widgets/__plugins__/form/components/form-tell-a-friend.js
@@ -4,10 +4,11 @@ import React, { PropTypes } from 'react'
 import * as paths from '~client/paths'
 import { TellAFriend } from '~components/share'
 
-const FormTellAFriend = ({ preview, mobilization }) => (
+const FormTellAFriend = ({ preview, mobilization, widget }) => (
   <TellAFriend
     preview={preview}
     mobilization={mobilization}
+    widget={widget}
     message='Formulário submetido com sucesso!'
     href={paths.mobilization(mobilization)}
   />
@@ -15,7 +16,8 @@ const FormTellAFriend = ({ preview, mobilization }) => (
 
 FormTellAFriend.propTypes = {
   preview: PropTypes.bool,
-  mobilization: PropTypes.object.isRequired
+  mobilization: PropTypes.object.isRequired,
+  widget: PropTypes.object.isRequired
 }
 
 export default FormTellAFriend

--- a/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
@@ -103,7 +103,7 @@ export class Pressure extends Component {
           finishMessageType === 'custom' ? (
             <FinishMessageCustom widget={widget} />
           ) : (
-            <PressureTellAFriend mobilization={mobilization} />
+            <PressureTellAFriend mobilization={mobilization} widget={widget} />
           )
         ) : (
           <div className='pressure-widget'>

--- a/client/mobilizations/widgets/__plugins__/pressure/components/pressure-tell-a-friend.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/pressure-tell-a-friend.js
@@ -2,17 +2,19 @@ import React, { PropTypes } from 'react'
 
 import { TellAFriend } from '~components/share'
 
-const PressureTellAFriend = ({ preview, mobilization }) => (
+const PressureTellAFriend = ({ preview, mobilization, widget }) => (
   <TellAFriend
     preview={preview}
     mobilization={mobilization}
+    widget={widget}
     message='Pressão enviada'
   />
 )
 
 PressureTellAFriend.propTypes = {
   preview: PropTypes.bool,
-  mobilization: PropTypes.object.isRequired
+  mobilization: PropTypes.object.isRequired,
+  widget: PropTypes.object.isRequired
 }
 
 export default PressureTellAFriend

--- a/client/mobilizations/widgets/components/form-finish-message/index-scss.js
+++ b/client/mobilizations/widgets/components/form-finish-message/index-scss.js
@@ -23,3 +23,9 @@ export const editorToolbar = ({
 export const editorContainer = ({
   minHeight: 315
 })
+
+export const whatsappControlLabel = ({
+  fontSize: '32px',
+  verticalAlign: 'middle',
+  color: '#005E52'
+})

--- a/client/mobilizations/widgets/components/form-finish-message/index.js
+++ b/client/mobilizations/widgets/components/form-finish-message/index.js
@@ -20,7 +20,7 @@ import EditorSlate, {
 import * as styles from './index-scss'
 
 export const FormFinishMessage = props => {
-  const { mobilization, fields, successMessage, ...rest } = props
+  const { mobilization, fields, successMessage, widget, ...rest } = props
   const { color_scheme: colorScheme } = mobilization
   const { TellAFriend } = props
 
@@ -52,8 +52,8 @@ export const FormFinishMessage = props => {
         <div>
           <FormGroup controlId='whatsapp-text-id' {...whatsappText}>
             <ControlLabel>
-              <i className='fa fa-whatsapp mr1' />
-              WhatsApp
+              <i className='fa fa-whatsapp mr2' style={styles.whatsappControlLabel} />
+              Texto do WhatsApp
             </ControlLabel>
             <FormControl
               rows='4'
@@ -67,7 +67,7 @@ export const FormFinishMessage = props => {
 
       <label className='h5 darkengray caps mb1 block'>Preview</label>
       {finishMessageType.value === 'share' && (
-        <TellAFriend preview mobilization={mobilization} />
+        <TellAFriend preview mobilization={mobilization} widget={widget} />
       )}
       {finishMessageType.value === 'custom' && (
         <div className='widget-finish-message-custom'>

--- a/client/mobilizations/widgets/components/form-finish-message/index.js
+++ b/client/mobilizations/widgets/components/form-finish-message/index.js
@@ -8,7 +8,8 @@ import {
   FormGroup,
   RadioGroup,
   Radio,
-  ControlLabel
+  ControlLabel,
+  FormControl
 } from '~components/forms'
 import Editor from '~components/editor-draft-js'
 import EditorSlate, {
@@ -25,7 +26,8 @@ export const FormFinishMessage = props => {
 
   const {
     finish_message_type: finishMessageType,
-    finish_message: finishMessage
+    finish_message: finishMessage,
+    whatsapp_text: whatsappText
   } = fields
 
   const parsedFinishMessage = editorValue(finishMessage.value)
@@ -45,6 +47,23 @@ export const FormFinishMessage = props => {
           <Radio value='custom'>Customizar</Radio>
         </RadioGroup>
       </FormGroup>
+
+      {finishMessageType.value === 'share' && (
+        <div>
+          <FormGroup controlId='whatsapp-text-id' {...whatsappText}>
+            <ControlLabel>
+              <i className='fa fa-whatsapp mr1' />
+              WhatsApp
+            </ControlLabel>
+            <FormControl
+              rows='4'
+              componentClass='textarea'
+              placeholder={'Faça um texto curto, capaz de motivar outras pessoas a se unirem à' +
+                ' sua mobilização. Você poderá alterar este texto depois.'}
+            />
+          </FormGroup>
+        </div>
+      )}
 
       <label className='h5 darkengray caps mb1 block'>Preview</label>
       {finishMessageType.value === 'share' && (
@@ -109,7 +128,8 @@ const editorValue = message => {
 const fields = [
   'finish_message_type',
   'finish_message',
-  'finish_message_background'
+  'finish_message_background',
+  'whatsapp_text'
 ]
 
 const validate = values => {
@@ -124,7 +144,8 @@ const mapStateToProps = (state, { widget: { settings } }) => ({
   initialValues: {
     finish_message_type: settings.finish_message_type || 'share',
     finish_message: settings.finish_message || createEditorContent('Clique aqui para editar...'),
-    finish_message_background: settings.finish_message_background || '255,255,255,1'
+    finish_message_background: settings.finish_message_background || '255,255,255,1',
+    whatsapp_text: settings.whatsapp_text || ''
   }
 })
 

--- a/test/client/unit/components/share/tell-a-friend.spec.js
+++ b/test/client/unit/components/share/tell-a-friend.spec.js
@@ -10,7 +10,8 @@ describe('client/components/share/tell-a-friend', () => {
     dispatch: () => {},
     href: 'http://foo.bar',
     message: 'Foo Bar Message',
-    mobilization: { twitter_share_text: 'Twitter Share Text' }
+    mobilization: { twitter_share_text: 'Twitter Share Text' },
+    widget: { settings: { whatsapp_text: 'Foo Bar' } }
   }
 
   beforeAll(() => {

--- a/test/client/unit/components/share/whatsapp-share-button.spec.js
+++ b/test/client/unit/components/share/whatsapp-share-button.spec.js
@@ -7,7 +7,8 @@ import { WhatsAppShareButton } from '~components/share'
 describe('client/components/share/whatsapp-share-button', () => {
   let wrapper
   const props = {
-    href: 'http://www.minhasampa.org.br'
+    href: 'http://www.minhasampa.org.br',
+    whatsappText: 'Foo Bar WhatsApp Text'
   }
 
   describe('#render', () => {
@@ -18,8 +19,9 @@ describe('client/components/share/whatsapp-share-button', () => {
     it('should render an <a /> tag element', () => {
       expect(wrapper.find('a')).to.have.length(1)
     })
-    it('should render an <a /> tag element with href containing whatsapp share link', () => {
-      expect(wrapper.find('a').props().href).to.be.equal(`whatsapp://send?text=${props.href}`)
+    it('should render an <a /> tag with its href properly', () => {
+      const text = encodeURIComponent(props.whatsappText)
+      expect(wrapper.find('a').props().href).to.be.equal(`whatsapp://send?text=${text}`)
     })
     it('should render className hide when desktop version', () => {
       expect(wrapper.find('a').props().className).to.contains('lg-hide')
@@ -27,6 +29,7 @@ describe('client/components/share/whatsapp-share-button', () => {
     it('should render without className hide when preview is true', () => {
       wrapper.setProps({ preview: true })
       expect(wrapper.find('a').props().className).to.not.contains('lg-hide')
+      wrapper.setProps(props)
     })
   })
 })


### PR DESCRIPTION
# Related issues
- Add option to set text to set whatsapp text share #487
- Better behavior with mobile when sharing #513

# How to test
- Access one of the routes below:
    - `/mobilizations/:mobilization_id/widgets/:widget_id/form/finish`
    - `/mobilizations/:mobilization_id/widgets/:widget_id/donation/finish`
    - `/mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish`
- With the **"Compartilhar"** option selected, the textarea to configure the whatsapp text must be rendered:
<img width="1154" alt="screen shot 2017-03-29 at 9 27 33 pm" src="https://cloud.githubusercontent.com/assets/5435389/24483108/4852c8e6-14cc-11e7-919a-db82c7052dbe.png">

- Save the form
- Do one of the actions:
    - Subscribe into a form entry
    - Make a donation
    - Make a pressure
- In each respective widget, in mobile device or in a small browser width, click on the whatsapp button to share and it must share the previously configured message with WhatsApp.

# Server dependant issues
- Add whatsapp_text into widget policy nossas/bonde-server#217