### PR TITLE
Fix finish custom message editor style

### DIFF
--- a/client/components/editor-draft-js/Toolbar/FontControls/SelectFontFamily.js
+++ b/client/components/editor-draft-js/Toolbar/FontControls/SelectFontFamily.js
@@ -17,14 +17,14 @@ const fonts = [
   'Slabo 27px', 'Source Sans Pro', 'Ubuntu'
 ]
 
-const SelectFontFamily = props => {
+const SelectFontFamily = props => (
   <select {...props} className='font-controls-family select col col-8 h5'>
     <option value=''>Selecione uma fonte</option>
     {fonts.map(
       font => <option key={font} value={font}>{font}</option>
     )}
   </select>
-}
+)
 
 SelectFontFamily.propTypes = {
   value: PropTypes.string.isRequired,

--- a/client/mobilizations/widgets/components/finish-message-custom.js
+++ b/client/mobilizations/widgets/components/finish-message-custom.js
@@ -26,6 +26,7 @@ const FinishMessageCustom = ({ readOnly, widget }) => {
     <EditorSlate
       content={finishMessage}
       readOnly={readOnly}
+      contentStyles={{ backgroundColor: '#fff', color: '#666', padding: 10 }}
     />
   )
 }

--- a/client/mobilizations/widgets/components/form-finish-message/index.js
+++ b/client/mobilizations/widgets/components/form-finish-message/index.js
@@ -93,7 +93,7 @@ export const FormFinishMessage = props => {
                   if (finishMessage.value !== raw) finishMessage.onChange(raw)
                 }}
                 toolbarStyles={{ position: 'relative', marginBottom: 10 }}
-                contentStyles={{ border: '1px solid #e1e1e1', color: '#666', padding: 10 }}
+                contentStyles={{ backgroundColor: '#fff', color: '#666', padding: 10 }}
               />
             )}
           </div>


### PR DESCRIPTION
# Related issues
- Change background color editor when editing custom message after pressure #524

# How to test
- Access widget finish custom message form
- The editor with slate must be like:

| **custom message slate-editor**                                                                                                                                          | **mobilization public view**                                                                                                                                 |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="624" alt="screen shot 2017-03-31 at 12 21 34 pm" src="https://cloud.githubusercontent.com/assets/5435389/24557067/c5f17aae-160c-11e7-826e-afcc3eb31e4c.png"> | <img width="337" alt="screen shot 2017-03-31 at 12 22 01 pm" src="https://cloud.githubusercontent.com/assets/5435389/24557068/c5f1b744-160c-11e7-946d-0515d9b49840.png"> |

- `background-color: #fff` by default
- `color: #666` by default