### PR TITLE
Add sidebar item that redirects to mobilization list page; Close #533

### DIFF
--- a/client/components/navigation/sidebar/sidebar.js
+++ b/client/components/navigation/sidebar/sidebar.js
@@ -10,6 +10,11 @@ const Sidebar = ({ children, loading, mobilization, user, community }) => loadin
       {!mobilization ? (
         <SidenavList className='bg-lighten-2'>
           <SidenavListItem
+            text='Minhas Mobilizações'
+            icon='list'
+            href={paths.mobilizations()}
+          />
+          <SidenavListItem
             text='Informações'
             icon='info-circle'
             href={paths.communityInfo()}

--- a/test/client/unit/components/navigation/sidebar/sidebar.spec.js
+++ b/test/client/unit/components/navigation/sidebar/sidebar.spec.js
@@ -110,6 +110,8 @@ describe('client/components/navigation/sidebar/sidebar', () => {
     })
 
     describe('when is not editing a mobilization', () => {
+      let itemIndex = -1
+      const incrementIndex = () => { itemIndex++ }
       beforeAll(() => {
         wrapper.setProps({ ...props, mobilization: undefined })
       })
@@ -118,63 +120,88 @@ describe('client/components/navigation/sidebar/sidebar', () => {
       })
 
       describe('community settings navbar items', () => {
+        describe('- minhas mobilizações', () => {
+          beforeAll(incrementIndex)
+
+          it('should render with its text properly', () => {
+            const text = 'Minhas Mobilizações'
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
+          })
+          it('should render with its icon properly', () => {
+            const icon = 'list'
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
+          })
+          it('should render with its href properly', () => {
+            const href = paths.mobilizations()
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
+          })
+        })
+
         describe('- informações', () => {
+          beforeAll(incrementIndex)
+
           it('should render with its text properly', () => {
             const text = 'Informações'
-            expect(wrapper.find('SidenavListItem').at(0).props().text).to.be.equal(text)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
           })
           it('should render with its icon properly', () => {
             const icon = 'info-circle'
-            expect(wrapper.find('SidenavListItem').at(0).props().icon).to.be.equal(icon)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
           })
           it('should render with its href properly', () => {
             const href = paths.communityInfo()
-            expect(wrapper.find('SidenavListItem').at(0).props().href).to.be.equal(href)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
           })
         })
 
         describe('- mailchimp', () => {
+          beforeAll(incrementIndex)
+
           it('should render with its text properly', () => {
             const text = 'Mailchimp'
-            expect(wrapper.find('SidenavListItem').at(1).props().text).to.be.equal(text)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
           })
           it('should render with its icon properly', () => {
             const icon = 'envelope-o'
-            expect(wrapper.find('SidenavListItem').at(1).props().icon).to.be.equal(icon)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
           })
           it('should render with its href properly', () => {
             const href = paths.communityMailchimp()
-            expect(wrapper.find('SidenavListItem').at(1).props().href).to.be.equal(href)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
           })
         })
 
         describe('- recebedor', () => {
+          beforeAll(incrementIndex)
+
           it('should render with its text properly', () => {
             const text = 'Recebedor'
-            expect(wrapper.find('SidenavListItem').at(2).props().text).to.be.equal(text)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
           })
           it('should render with its icon properly', () => {
             const icon = 'money'
-            expect(wrapper.find('SidenavListItem').at(2).props().icon).to.be.equal(icon)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
           })
           it('should render with its href properly', () => {
             const href = paths.communityRecipient()
-            expect(wrapper.find('SidenavListItem').at(2).props().href).to.be.equal(href)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
           })
         })
 
         describe('- relatório', () => {
+          beforeAll(incrementIndex)
+
           it('should render with its text properly', () => {
             const text = 'Relatório'
-            expect(wrapper.find('SidenavListItem').at(3).props().text).to.be.equal(text)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
           })
           it('should render with its icon properly', () => {
             const icon = 'file-excel-o'
-            expect(wrapper.find('SidenavListItem').at(3).props().icon).to.be.equal(icon)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
           })
           it('should render with its href properly', () => {
             const href = paths.communityReport()
-            expect(wrapper.find('SidenavListItem').at(3).props().href).to.be.equal(href)
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
           })
         })
       })


### PR DESCRIPTION
# Related issues
- Add an item on the sidebar that redirects to mobilization list page #533

# How to test
- Open the mobilization list page
- You must see the "Minhas Mobilizações" item on the sidebar

<img width="277" alt="screen shot 2017-04-04 at 3 07 44 pm" src="https://cloud.githubusercontent.com/assets/5435389/24676032/bd748c2e-1957-11e7-92d3-3dff94b6efc2.png">
