### PR TITLE
Add twitter cards markup tags into mobilization's public view

### DIFF
--- a/routes/custom-domain/page.js
+++ b/routes/custom-domain/page.js
@@ -54,6 +54,11 @@ class CustomDomainPage extends Component {
             title={name}
             meta={[
               { name: 'description', content: goal },
+              { name: 'twitter:card', content: 'summary_large_image' },
+              { name: 'twitter:title', content: facebookShareTitle },
+              { name: 'twitter:description', content: facebookShareDescription },
+              { name: 'twitter:image', content: facebookShareImage },
+              { property: 'twitter:url', content: host },
               { property: 'og:url', content: host },
               { property: 'og:title', content: facebookShareTitle },
               { property: 'og:description', content: facebookShareDescription },


### PR DESCRIPTION
# Related issues
- Add twitter card meta tags #532

# How to test

- Choose a mobilization e.g. MSP (http://www.39-layout-minha-sampa-versao-02.bonde-client.reboo-staging.org/) and run the command below:
```bash
curl -A Twitterbot http://www.39-layout-minha-sampa-versao-02.bonde-client.reboo-staging.org/
```

- Check if the following meta tags are inside `<head>`:
```html
    <meta data-react-helmet="true" name="twitter:card" content="summary_large_image" />
    <meta data-react-helmet="true" name="twitter:title" content="Vamos juntos mudar a cara da nossa cidade?" />
    <meta data-react-helmet="true" name="twitter:description" content="Faça parte da nossa rede de mobilização por uma SP mais justa e gostosa de se viver. " />
    <meta data-react-helmet="true" name="twitter:image" content="https://s3.amazonaws.com/hub-central/uploads/1449146828_meme_membro.png" />
    <meta data-react-helmet="true" property="twitter:url" content="www.39-layout-minha-sampa-versao-02.bonde-client.reboo-staging.org" />
```

- Get the same URL e.g. http://www.39-layout-minha-sampa-versao-02.bonde-client.reboo-staging.org/ and post a tweet in Twitter

- The tweet must render as following:
<img width="597" alt="screen shot 2017-04-07 at 11 35 03 am" src="https://cloud.githubusercontent.com/assets/5435389/24804883/49b965e4-1b86-11e7-8c53-3d2dc0c80724.png">

---

Or you can simply use the [Twitter Card Validator](https://cards-dev.twitter.com/validator) previewing the URL card tags