### PR TITLE
Hotfix mobilization launch horizontal scroll

### DIFF
--- a/client/components/layout/settings-page-content-layout.js
+++ b/client/components/layout/settings-page-content-layout.js
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 const SettingsPageContentLayout = ({ children, className, containerClassName, wrapClassName }) => (
   <div
     className={classnames(
-      'settings-page-content-layout clearfix overflow-auto py3 pr4 pl3',
+      'settings-page-content-layout clearfix overflow-auto py3 pr4 pl3 border-box',
       className
     )}
   >


### PR DESCRIPTION
# Related issues
- Scroll in horizontal and verical bars when lauching mobilization #548

# How to test
- Access the mobilization launch flow page e.g. http://app.staging.bonde.org/mobilizations/417/launch (Community: "Adventure Time")
- The page content should not have horizontal scroll