### PR TITLE
Force use custom domain as og:url fixes #569

### DIFF
--- a/routes/custom-domain/page.js
+++ b/routes/custom-domain/page.js
@@ -48,6 +48,8 @@ class CustomDomainPage extends Component {
         body_font: bodyFont
       } = mobilization
 
+      const url = mobilization.custom_domain || host
+
       return (
         <div>
           <Helmet
@@ -58,8 +60,8 @@ class CustomDomainPage extends Component {
               { name: 'twitter:title', content: facebookShareTitle },
               { name: 'twitter:description', content: facebookShareDescription },
               { name: 'twitter:image', content: facebookShareImage },
-              { property: 'twitter:url', content: host },
-              { property: 'og:url', content: host },
+              { property: 'twitter:url', content: url },
+              { property: 'og:url', content: url },
               { property: 'og:title', content: facebookShareTitle },
               { property: 'og:description', content: facebookShareDescription },
               { property: 'og:image', content: facebookShareImage }


### PR DESCRIPTION
# Description
If custom domain is configured in the mobilization settings,
use it on og:url in public view of the mobilization. If it not
exists, use the slug instead.

# Related issues
- Share button after pressure link to slug domain #569

# How to test
- Open a mobilization that have a custom domain configured in the public view
- Access it using the slug
- Inspect and the `og:url` meta tag should be have the value as custom domain