### PR TITLE
Fix href prop passed to TellAFriend

### DIFF
--- a/client/components/share/tell-a-friend.connected.js
+++ b/client/components/share/tell-a-friend.connected.js
@@ -1,9 +1,15 @@
 import { connect } from 'react-redux'
 import TellAFriend from './tell-a-friend'
+import MobSelectors from '~client/mobrender/redux/selectors'
 
-const mapStateToProps = ({ sourceRequest: { protocol, host } }) => ({
-  href: `${protocol}://${host}`
-})
+const mapStateToProps = state => {
+  const { sourceRequest: { protocol, host } } = state
+  const { custom_domain: customDomain } = MobSelectors(state).getMobilization()
+
+  return {
+    href: customDomain || `${protocol}://${host}`
+  }
+}
 
 export { default as TellAFriend } from './tell-a-friend'
 export default connect(mapStateToProps)(TellAFriend)


### PR DESCRIPTION
# Description
Even with `og:url` with custom domain forced, the
TellAFriend component do not receiving the correct prop.

# Related issues
- Share button after pressure link to slug domain #569

# How to test
- Open a mobilization in the public view
- Make a donation, pressure or subscribe into a form entry
- In the widget success message, click on **Share with Facebook** or **Share with Twitter**
- The URL should be with mobilization custom domain if it has a custom domain configured or a slug if it's not.