### PR TITLE
Fix scroll when loads the client bundle

### DIFF
--- a/routes/custom-domain/page.js
+++ b/routes/custom-domain/page.js
@@ -17,6 +17,15 @@ if (require('exenv').canUseDOM) {
 
 class CustomDomainPage extends Component {
   componentDidMount () {
+    //
+    // Fix scroll when loads the client bundle.
+    // After the initial render that the server responds.
+    //
+    if (require('exenv').canUseDOM && window.location.hash) {
+      const target = document.querySelector(window.location.hash)
+      target && target.scrollIntoView()
+    }
+
     const isTest = process.env.NODE_ENV === undefined || process.env.NODE_ENV === 'test'
     if (!isTest) {
       const { mobilization } = this.props

--- a/routes/custom-domain/page.js
+++ b/routes/custom-domain/page.js
@@ -17,13 +17,25 @@ if (require('exenv').canUseDOM) {
 
 class CustomDomainPage extends Component {
   componentDidMount () {
-    //
-    // Fix scroll when loads the client bundle.
-    // After the initial render that the server responds.
-    //
-    if (require('exenv').canUseDOM && window.location.hash) {
-      const target = document.querySelector(window.location.hash)
-      target && target.scrollIntoView()
+    if (require('exenv').canUseDOM) {
+      //
+      // Fix scroll when loads the client bundle.
+      // After the initial render that the server responds.
+      //
+      if (window.location.hash) {
+        const hashTarget = document.querySelector(window.location.hash)
+        hashTarget && hashTarget.scrollIntoView()
+      }
+
+      //
+      // Get the current scroll position from the initial render
+      // to prevent the browser rescroll to top when the client bundle loads.
+      //
+      if (window.scrollPosition) {
+        const blocksList = document.getElementById('blocks-list')
+        const propagateScroll = target => { target.scrollTop = window.scrollPosition }
+        blocksList && propagateScroll(blocksList)
+      }
     }
 
     const isTest = process.env.NODE_ENV === undefined || process.env.NODE_ENV === 'test'

--- a/server/index.js
+++ b/server/index.js
@@ -34,7 +34,7 @@ import createRoutes from '../routes'
 import loadState from './load-state'
 
 export const createServer = (config) => {
-  const __PROD__ = config.nodeEnv === 'production' || config.nodeEnv === 'staging' ? true : false
+  const __PROD__ = config.nodeEnv === 'production' || config.nodeEnv === 'staging'
   const __TEST__ = config.nodeEnv === 'test'
 
   const app = express()
@@ -198,6 +198,11 @@ export const createServer = (config) => {
               <body>
                 <div id="root">${data}</div>
                 <script>window.INITIAL_STATE = ${JSON.stringify(initialState)};</script>
+                <script type="text/javascript">
+                  document.getElementById('blocks-list').onscroll = function() {
+                    window.scrollPosition = document.getElementById('blocks-list').scrollTop
+                  };
+                </script/>
                 <script src="${__PROD__ ? 'https://s3-sa-east-1.amazonaws.com/bonde-assets/public' : ''}/wysihtml/wysihtml-toolbar.min.js"></script>
                 <script src="${__PROD__ ? assets.vendor.js : '/vendor.bundle.js'}"></script>
                 <script async src="${__PROD__ ? assets.main.js : '/main.bundle.js'}" ></script>


### PR DESCRIPTION
# Description
When the URL have a hash pointing to an element id,
scroll to it on the client bundle. The problem was
that the initial render responded by server did the
scroll but, when the client bundle was loaded, the
scroll was back to the top.

# Related issues
- Wierd scroll to top after first load from mobilization #478

# How to test

**Fragment case**
- Access a mobilization with a hash on URL that points to a block e.g. http://www.39-layout-minha-sampa-versao-02.staging.bonde.org/#block-264
- After initial render, the scroll should not back to the top.

**Initial render scroll case**
- Access a mobilization public view and scroll until page are loading
- After the page assets finish loading, the page scroll must still the same as scrolled before.