### PR TITLE
Fix pressure target regex

### DIFF
--- a/routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.js
+++ b/routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.js
@@ -6,7 +6,7 @@ import { InputTag } from '~client/mobilizations/widgets/components'
 
 // Regex to validate Target (Ex.: Igor Santos <igor@nossascidades.org>)
 // eslint-disable-next-line
-const patternTarget = /[\w]+[ ]*<(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))>/
+const patternTarget = /[a-zà-úA-ZÀ-Ú\s]+<(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))>/
 
 class PressureSettingsEmailPage extends Component {
   constructor (props) {


### PR DESCRIPTION
# Related issues
- Pressure widget regex validation when target name contains accents #568

# How to test
- Choose a mobilization that contains a pressure widget and enter to edit it
- Click on the pressure widget to access the settings of the widget
- Select the **"Email para alvo"** tab
- Fill the target input with target name that contains accents.
e.g. `Filipe Sabará <smads@prefeitura.sp.gov.br>`
- The validation should accepts the target name with accents without errors.