### PR TITLE
Add custom from email to community settings

### DIFF
--- a/client/mobrender/redux/action-creators/async-filter-block.js
+++ b/client/mobrender/redux/action-creators/async-filter-block.js
@@ -3,10 +3,10 @@ import { createAction } from './create-action'
 import * as t from '../action-types'
 
 export default where => (dispatch, getState, { api }) => {
-  const { auth: { credentials } } = getState()
+  // const { auth: { credentials } } = getState()
 
   const endpoint = '/blocks'
-  const config = { headers: credentials, params: where }
+  const config = { params: where }
 
   dispatch({ type: t.FILTER_BLOCKS_REQUEST })
   return api

--- a/client/mobrender/redux/action-creators/async-filter-widget.js
+++ b/client/mobrender/redux/action-creators/async-filter-widget.js
@@ -2,10 +2,10 @@ import * as t from '../action-types'
 import { createAction } from './create-action'
 
 export default where => (dispatch, getState, { api }) => {
-  const { auth: { credentials } } = getState()
+  // const { auth: { credentials } } = getState()
 
   const endpoint = '/widgets'
-  const config = { headers: credentials, params: where }
+  const config = { params: where }
 
   dispatch({ type: t.FILTER_WIDGETS_REQUEST })
   return api

--- a/client/utils/validation-helper.js
+++ b/client/utils/validation-helper.js
@@ -13,3 +13,13 @@ const regexDDMMYYYY = /^\d{2}\/\d{2}\/\d{4}$/ // 00/00/0000
 export const date = value => ({
   ddmmyyyy: regexDDMMYYYY.test(value)
 })
+
+// Validate email from
+export const isValidFromEmail = value => {
+  const regex = /^[\w ]+\<(.*)\>$/
+  if (regex.test(value)) {
+    const email = value.match(regex)[1]
+    return isValidEmail(email)
+  }
+  return false
+}

--- a/client/utils/validation-helper.spec.js
+++ b/client/utils/validation-helper.spec.js
@@ -47,4 +47,42 @@ describe('client/utils/validation-helper', () => {
       expect(validator.isValidCodeGA('MO-87654321-0123123123')).to.be.true
     })
   })
+
+  describe('isValidFromEmail', () => {
+    it('should return false for " <>"', () => {
+      expect(validator.isValidFromEmail(' <>')).to.equal(false)
+    })
+
+    it('should return false for "I9 <>"', () => {
+       expect(validator.isValidFromEmail('I9 <>')).to.equal(false)
+    })
+
+    it('should return false for "I9"', () => {
+      expect(validator.isValidFromEmail('I9')).to.equal(false)
+    })
+
+    it('should return false for "I9 <contact@i9.org"', () => {
+      expect(validator.isValidFromEmail('I9 <contact@i9.org')).to.equal(false) 
+    })
+
+    it('should return false for "I9 contact@i9.org>"', () => {
+      expect(validator.isValidFromEmail('I9 contact@i9.org>')).to.equal(false) 
+    })
+
+    it('should return false for "I9 <contact@org>"', () => {
+      expect(validator.isValidFromEmail('I9 <contact@org>')).to.equal(false) 
+    })
+
+    it('should return false for "I9 <@i9.org>"', () => {
+      expect(validator.isValidFromEmail('I9 <@i9.org>')).to.equal(false) 
+    })
+
+    it('should return false for "I9 <contacti9.org>"', () => {
+      expect(validator.isValidFromEmail('I9 <contacti9.org>')).to.equal(false) 
+    })
+
+    it('should return true for "I9 <contact@i9.org>"', () => {
+      expect(validator.isValidFromEmail('I9 <contact@i9.org>')).to.equal(true) 
+    })
+  })
 })

--- a/routes/admin/authenticated/sidebar/community-settings/info/page.connected.js
+++ b/routes/admin/authenticated/sidebar/community-settings/info/page.connected.js
@@ -3,6 +3,7 @@ import { reduxForm } from 'redux-form'
 
 import { asyncEdit } from '~client/community/action-creators'
 import * as CommunitySelectors from '~client/community/selectors'
+import { isValidFromEmail } from '~client/utils/validation-helper'
 
 import Page from './page'
 
@@ -16,16 +17,21 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = { submit: asyncEdit }
 
-const fields = ['id', 'image', 'name', 'city', 'description']
+const fields = [
+  'id', 'image', 'name', 'city', 'description', 'custom_from_email'
+]
 
-const validate = values => {
+const validate = ({ name, city, custom_from_email: customFromEmail }) => {
   const errors = {}
 
-  if (!values.name) {
+  if (!name) {
     errors.name = 'Informe o nome da comunidade'
   }
-  if (!values.city) {
+  if (!city) {
     errors.city = 'Informe em qual cidade sua comunidade atua'
+  }
+  if (customFromEmail && !isValidFromEmail(customFromEmail)) {
+    errors.custom_from_email = 'E-mail de resposta fora do formato padrão'
   }
   return errors
 }

--- a/routes/admin/authenticated/sidebar/community-settings/info/page.js
+++ b/routes/admin/authenticated/sidebar/community-settings/info/page.js
@@ -5,12 +5,15 @@ import {
   FormGroup,
   FormControl,
   ControlLabel,
-  UploadImageField
+  UploadImageField,
+  HelpBlock
 } from '~client/components/forms'
 import { SettingsForm } from '~client/ux/components'
 
 const CommunitySettingsInfoPage = ({
-  fields: { image, name, city, description },
+  fields: {
+    image, name, city, description, custom_from_email: customFromEmail
+  },
   location,
   community,
   downloadActivists,
@@ -20,16 +23,24 @@ const CommunitySettingsInfoPage = ({
     <FormGroup controlId='imageId' {...image}>
       <UploadImageField signingUrl={`${process.env.API_URL}/uploads`} />
     </FormGroup>
-    <FormGroup controlId='nameId' {...name}>
+    <FormGroup controlId='nametId' {...name}>
       <ControlLabel>Nome</ControlLabel>
       <FormControl type='text' />
     </FormGroup>
     <FormGroup controlId='descriptionId' {...description}>
       <ControlLabel>Descrição</ControlLabel>
-      <FormControl componentClass='textarea' />
+      <FormControl componentusClass='textarea' />
     </FormGroup>
     <FormGroup controlId='cityId' {...city}>
       <ControlLabel>Cidade</ControlLabel>
+      <FormControl type='text' />
+    </FormGroup>
+    <FormGroup controlId='customFromEmail' {...customFromEmail}>
+      <ControlLabel>E-mail de resposta para notificações</ControlLabel>
+      <HelpBlock>
+        {`Você deve preencher seguindo o formato padrão:
+          Nome do contato <contato@provedor.com>`}
+      </HelpBlock>
       <FormControl type='text' />
     </FormGroup>
   </SettingsForm>


### PR DESCRIPTION
## Issues

- Closes #587 Add from_email to community config

## How to test

- Open page to settings community on tab "Informations"
- On bottom has a new field "From email to notifications"
- Insert a pattern value like "Full Name <name@server.org>"