### PR TITLE
Feature better handle with inputs when on mobile device

### DIFF
--- a/client/mobilizations/widgets/__plugins__/form/components/input.js
+++ b/client/mobilizations/widgets/__plugins__/form/components/input.js
@@ -97,7 +97,7 @@ class Input extends Component {
           }}
           onBlur={onBlur}
           placeholder={field.placeholder}
-          type='text'
+          type={field.kind === 'email' ? 'email' : 'text'}
         />
       )
     }


### PR DESCRIPTION
# Related issues
- Better handle with inputs when mobile #544

# How to test
- Open a mobilization that contains the form and pressure widgets in the public view
e.g.http://www.405-teste-slate-editor-v2-4-1.staging.bonde.org/
- The email fields should be of type `email`