### PR TITLE
Feature create intl entry points with pt br

### DIFF
--- a/client/components/filterable-search-bar/index.js
+++ b/client/components/filterable-search-bar/index.js
@@ -11,7 +11,7 @@ export class FilterableSearchBar extends Component {
   }
 
   render () {
-    const { list, dispatch } = this.props
+    const { list, dispatch, placeholder } = this.props
     return (
       <div
         className='bg-white rounded-top border-only-bottom border-whisper flex flex-wrap'
@@ -20,7 +20,7 @@ export class FilterableSearchBar extends Component {
         <i className='fa fa-search black pt1' style={{ fontSize: '1.1rem' }} />
         <input
           className='input border-none col-11 inline-block mb0'
-          placeholder='Busque um template'
+          placeholder={placeholder}
           style={{ fontSize: '1.2rem' }}
           onChange={input => {
             dispatch(setFilterableSearchBarList(

--- a/client/mobilizations/components/page-header.js
+++ b/client/mobilizations/components/page-header.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-// Global module dependencies
 import * as paths from '~client/paths'
 import { Tabs, Tab } from '~client/components/navigation/tabs'
 import { DivFloat, Button } from '~client/ux/components'

--- a/client/mobilizations/templates/components/template-selectable-list.js
+++ b/client/mobilizations/templates/components/template-selectable-list.js
@@ -24,7 +24,7 @@ const TemplateSelectableList = props => {
 
   return (
     <div className='mobilization-templates-selectable-list'>
-      <FilterableSearchBar list={templates} />
+      <FilterableSearchBar list={templates} placeholder='Busque um template' />
 
       <div className='bg-white rounded-bottom' style={{ padding: '1.6rem 2rem' }}>
         <SelectableList

--- a/client/mobilizations/widgets/__plugins__/donation/components/__donation__/index.js
+++ b/client/mobilizations/widgets/__plugins__/donation/components/__donation__/index.js
@@ -161,57 +161,57 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
                 onClick={::this.handleClickSetValueDonation.bind(this, 1)}
                 style={selectedValue !== 1 ? {} : { backgroundColor: this.convertHex(mainColor, 35), color: mainColor }}
                 className={classnames('value-option block mb1 py1 col-12 bold hover no-underscore', selectedValue === 1 ? 'active' : 'bg-darken-1')}
-            >
+              >
                 {'R$ ' + donationValue1 + (paymentType === 'recurring' || (selectedPaymentType === 'recurring' && paymentType !== 'unique') ? ' /' : '') + periodLabel}
               </a>
-          )}
+            )}
             {donationValue2 <= 0 ? null : (
               <a
                 href='#'
                 onClick={::this.handleClickSetValueDonation.bind(this, 2)}
                 style={selectedValue !== 2 ? {} : { backgroundColor: this.convertHex(mainColor, 35), color: mainColor }}
                 className={classnames('value-option block mb1 py1 col-12 bold hover no-underscore', selectedValue === 2 ? 'active' : 'bg-darken-1')}
-            >
+              >
                 {'R$ ' + donationValue2 + (paymentType === 'recurring' || (selectedPaymentType === 'recurring' && paymentType !== 'unique') ? ' /' : '') + periodLabel}
               </a>
-          )}
+            )}
             {donationValue3 <= 0 ? null : (
               <a
                 href='#'
                 onClick={::this.handleClickSetValueDonation.bind(this, 3)}
                 style={selectedValue !== 3 ? {} : { backgroundColor: this.convertHex(mainColor, 35), color: mainColor }}
                 className={classnames('value-option block mb1 py1 col-12 bold hover no-underscore', selectedValue === 3 ? 'active' : 'bg-darken-1')}
-            >
+              >
                 {'R$ ' + donationValue3 + (paymentType === 'recurring' || (selectedPaymentType === 'recurring' && paymentType !== 'unique') ? ' /' : '') + periodLabel}
               </a>
-          )}
+            )}
             {donationValue4 <= 0 ? null : (
               <a
                 href='#'
                 onClick={::this.handleClickSetValueDonation.bind(this, 4)}
                 style={selectedValue !== 4 ? {} : { backgroundColor: this.convertHex(mainColor, 35), color: mainColor }}
                 className={classnames('value-option block mb1 py1 col-12 bold hover no-underscore', selectedValue === 4 ? 'active' : 'bg-darken-1')}
-            >
+              >
                 {'R$ ' + donationValue4 + (paymentType === 'recurring' || (selectedPaymentType === 'recurring' && paymentType !== 'unique') ? ' /' : '') + periodLabel}
               </a>
-          )}
+            )}
             {donationValue5 <= 0 ? null : (
               <a
                 href='#'
                 onClick={::this.handleClickSetValueDonation.bind(this, 5)}
                 style={selectedValue !== 5 ? {} : { backgroundColor: this.convertHex(mainColor, 35), color: mainColor }}
                 className={classnames('value-option block mb1 py1 col-12 bold hover no-underscore', selectedValue === 5 ? 'active' : 'bg-darken-1')}
-            >
+              >
                 {'R$ ' + donationValue5 + (paymentType === 'recurring' || (selectedPaymentType === 'recurring' && paymentType !== 'unique') ? ' /' : '') + periodLabel}
               </a>
-          )}
+            )}
 
             <a
               href='#'
               onClick={::this.handleClickDonate}
               style={{ backgroundColor: mainColor }}
               className='btn white caps bg-darken-4 p2 mt1 col-12 rounded border-box'
-          >
+            >
               {buttonText}
             </a>
           </div>
@@ -228,21 +228,6 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 
     let result = 'rgba(' + r + ',' + g + ',' + b + ',' + opacity / 100 + ')'
     return result
-  }
-
-  renderOverlay () {
-    const { editable, configurable } = this.props
-    if (editable && !configurable && this.state.hasMouseOver) {
-      return (
-        <div className='absolute top-0 right-0 bottom-0 left-0 bg-darken-4 h1 bold rounded z1'>
-          <div className='table full-height col-12 center'>
-            <div className='white table-cell align-middle'>
-              Clique para editar
-            </div>
-          </div>
-        </div>
-      )
-    }
   }
 
   renderForm () {

--- a/client/mobilizations/widgets/__plugins__/form/components/__form__.js
+++ b/client/mobilizations/widgets/__plugins__/form/components/__form__.js
@@ -147,21 +147,6 @@ class Form extends Component {
     }
   }
 
-  renderOverlay () {
-    const { editable, configurable } = this.props
-    if (editable && !configurable && this.state.hasMouseOver) {
-      return (
-        <div className='absolute top-0 right-0 bottom-0 left-0 bg-darken-4 h1 bold rounded z1'>
-          <div className='table full-height col-12 center'>
-            <div className='white table-cell align-middle'>
-              Clique para editar
-            </div>
-          </div>
-        </div>
-      )
-    }
-  }
-
   renderErrors () {
     const { errors } = this.state
 
@@ -206,7 +191,6 @@ class Form extends Component {
           {this.renderFields()}
           {this.renderErrors()}
           {this.renderButton()}
-          {this.renderOverlay()}
         </div>
       </div>
     )
@@ -221,17 +205,10 @@ class Form extends Component {
     const { success } = this.state
 
     return (
-      <WidgetOverlay
-        editable={editable}
-        onClick={::this.handleOverlayOnClick}
-        text='Clique para configurar o formulário de inscrição'
-      >
-        <div onKeyDown={(e) => e.stopPropagation()} />
-        <div className={`widget ${headerFont}-header`}>
-          {success ? this.renderShareButtons() : this.renderForm()}
-          {this.renderCount()}
-        </div>
-      </WidgetOverlay>
+      <div className={`widget ${headerFont}-header`}>
+        {success ? this.renderShareButtons() : this.renderForm()}
+        {this.renderCount()}
+      </div>
     )
   }
 }

--- a/client/mobilizations/widgets/components/form-finish-message/index.js
+++ b/client/mobilizations/widgets/components/form-finish-message/index.js
@@ -49,7 +49,7 @@ export const FormFinishMessage = props => {
       }}
       successMessage={successMessage || 'Formulário salvo com sucesso!'}
     >
-      <FormGroup controlId='payment-type-id' {...finishMessageType}>
+      <FormGroup controlId='finish-message-type-id' {...finishMessageType}>
         <ControlLabel>Tipo de mensagem</ControlLabel>
         <RadioGroup>
           <Radio value='share'>Compartilhar</Radio>

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -322,4 +322,15 @@ export default {
   'page--mobilizations.templates-choose.browsable-list-item.blank': 'Criar mobilização do zero',
   'page--mobilizations.templates-choose.browsable-list-item.templates-custom': 'Meus templates',
   'page--mobilizations.templates-choose.browsable-list-item.templates-global': 'Templates globais',
+
+  // component mobilizations templates selectable list
+  // filepath: /client/mobilizations/templates/components/template-selectable-list.js
+  'templates.components--selectable-list.filterable-search-bar.placeholder': 'Busque um template',
+  'templates.components--selectable-list.empty-list-text': 'Não existe nenhum template com esse nome',
+  'templates.components--selectable-list.button.back': 'Voltar',
+  'templates.components--selectable-list.button.next': 'Continuar',
+
+  // page mobilizations templates choose custom
+  // filepath: /routes/admin/authenticated/sidebar/templates-choose-custom/page.js
+  'page--mobilizations.templates-choose-custom.title': 'Meus Templates',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -718,4 +718,21 @@ export default {
   // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/pressure/page.connected.js
   'page--pressure-widget.form.validation.title-text.required': 'Insira um título para o formulário',
   'page--pressure-widget.form.validation.button-text.required': 'Insira um texto para o botão',
+
+  // component widgets input tag
+  // filepath: /client/mobilizations/widgets/components/input-tag.js
+  'widgets.components--input-tag.helper-text.target-format': '1. Informe nome e email. Ex.: Nome <email@provedor.com>',
+  'widgets.components--input-tag.helper-text.enter-to-add': '2. Pressione <Enter> para adicionar mais alvos.',
+
+  // page pressure widget email
+  // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.js
+  'page--pressure-widget-email.success-message': 'Email para alvo configurado com sucesso!',
+  'page--pressure-widget-email.form.input-tag.label': 'Alvos',
+  'page--pressure-widget-email.form.input-tag.validation.invalid-target-format': 'Alvo fora do formato padrão. Ex.: Nome do alvo <alvo@provedor.com>',
+  'page--pressure-widget-email.form.email-subject.label': 'Assunto do email',
+  'page--pressure-widget-email.form.email-body.label': 'Corpo do email que será enviado',
+
+  // page pressure widget email (connected)
+  // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.connected.js
+  'page--pressure-widget-email.form.validation.required': 'Preenchimento obrigatório',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -51,4 +51,12 @@ export default {
   'form--subscription-creditcard.form.cvv.placeholder': 'Ex: 000',
   'form--subscription-creditcard.form.submit-button.text': 'Salvar',
   'form--subscription-creditcard.form.validation.required': 'Obrigatório',
+
+  // form subscription recurring
+  'form--subscription-recurring.helper-text': 'Preencha os campos abaixo para alterar a data em que a cobrança da sua doação é efetuada. Sua doação continuará a mesma mas, a partir do momento em que salvar os dados abaixo, o valor será cobrado neste novo cartão ; )',
+  'form--subscription-recurring.form.process-at.label': 'Nova data de cobrança',
+  'form--subscription-recurring.form.process-at.placeholder': 'Ex: DD/MM/AAAA',
+  'form--subscription-recurring.form.submit-button.text': 'Salvar',
+  'form--subscription-recurring.form.validation.required': 'Obrigatório',
+  'form--subscription-recurring.form.validation.invalid-date-format': 'Formato de data inválido',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -359,4 +359,14 @@ export default {
   // page mobilizations settings analytics (connected)
   // filepath: /routes/admin/authenticated/sidebar/mobilizations-settings-analytics/page.connected.js
   'page--mobilizations-analytics.ol.form.ga-code.validation.invalid.ga-code.format': 'Informe uma ID válida',
+
+  // page block create
+  // filepath: /routes/admin/authenticated/sidebar/blocks-create/page.js
+  'page--block-create.title': 'Adicione um bloco de conteúdo',
+  'page--block-create.tabs.blank-blocks': 'Blocos em branco',
+  'page--block-create.helper-text': 'Os blocos serão adicionados ao fim da sua página, mas você pode trocá-los de ordem a qualquer momento',
+  'page--block-create.type.label': 'Tipo de bloco',
+  'page--block-create.background.label': 'Fundo',
+  'page--block-create.background.image.placeholder.text': 'Selecione a imagem de fundo',
+  'page--block-create.button-add.text': 'Adicionar',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -132,5 +132,10 @@ export default {
   'page--community-domain-create.step-check.second-paragraph': 'Atenção: a mudança de DNS pode demorar até 48 horas para ser propagada pela internet.',
   'page--community-domain-create.step-check.button.text': 'Testar',
 
-
+  // page community info
+  'page--community-info.form.name.label': 'Nome',
+  'page--community-info.form.description.label': 'Descrição',
+  'page--community-info.form.city.label': 'Cidade',
+  'page--community-info.form.custom-from-email.label': 'E-mail de resposta para notificações',
+  'page--community-info.form.custom-from-email.helper-text': 'Você deve preencher seguindo o formato padrão: Nome do contato <contato@provedor.com>',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -470,4 +470,12 @@ export default {
   'page--templates-list.more-menu-action.remove.text': 'Remover',
   'page--templates-list.more-menu-action.remove.confirm': 'Tem certeza que deseja remover este template? Ao confirmar, não é possível desfazer esta ação.',
   'page--templates-list.more-menu-action.remove.confirm': 'Tem certeza que deseja remover este template? Ao confirmar, não é possível desfazer esta ação.',
+
+  // page templates create
+  // filepath: /routes/admin/authenticated/sidebar/templates-create/page.js
+  'page--templates-create.header.title': 'Crie um template a partir da mobilização',
+  'page--templates-create.form.name.label': 'Nome do seu template',
+  'page--templates-create.form.name.placeholder': 'Pela criação de uma delegacia de desaparecidos',
+  'page--templates-create.form.goal.label': 'Descrição',
+  'page--templates-create.form.goal.placeholder': 'Faça um texto curto, capaz de motivar outras pessoas a se unirem à sua mobilização. Você poderá alterar este texto depois.',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -38,9 +38,11 @@ export default {
 
   // form subscription credit card
   'form--subscription-creditcard.helper-text': 'Altere os dados do seu cartão de crédito preenchendo os campos abaixo. Sua doação continuará a mesma mas, a partir do momento em que salvar os dados abaixo, o valor será cobrado neste novo cartão ; )',
+
   'form--subscription-creditcard.previous-data.title': 'Dados do último cartão',
   'form--subscription-creditcard.previous-data.name': 'Nome',
   'form--subscription-creditcard.previous-data.expiration-date': 'Validade',
+
   'form--subscription-creditcard.form.number.label': 'Número',
   'form--subscription-creditcard.form.number.placeholder': 'Ex: 0000 0000 0000 0000',
   'form--subscription-creditcard.form.name.label': 'Nome',
@@ -94,6 +96,7 @@ export default {
   'page--community-domain.section--dns-hosted-zone.menu.remove': 'Remover domínio',
   'page--community-domain.section--dns-hosted-zone.menu.remove.dialog.text': 'Tem certeza que deseja remover o domínio {domainName}?',
   'page--community-domain.section--dns-hosted-zone.menu.check-dns': 'Verificar DNS',
+
   'page--community-domain.section--dns-records.title': 'Subdomínios externos',
   'page--community-domain.section--dns-records.add': 'Adicionar novo subdomínio externo',
   'page--community-domain.section--dns-records.menu.remove': 'Remover subdomínio',
@@ -102,4 +105,24 @@ export default {
   // component dialog
   'ux.components--dialog.button.confirm.text': 'Confirmar',
   'ux.components--dialog.button.cancel.text': 'Cancelar',
+
+  // page community create
+  'page--community-domain-create.title': 'Domínio da comunidade',
+
+  'page--community-domain-create.step-add.title': 'Insira o domínio desejado',
+  'page--community-domain-create.step-add.form.domain-name.label': 'Domínio da sua comunidade',
+  'page--community-domain-create.step-add.form.domain-name.placeholder': 'Ex. minhacomunidade.org',
+  'page--community-domain-create.step-add.form.button.text': 'Adicionar',
+
+  'page--community-domain-create.step-dns-servers.title': 'Altere os servidores do seu provedor DNS',
+  'page--community-domain-create.step-dns-servers.first-paragraph': '1. Faça login no seu provedor de DNS (onde seu domínio está registrado, por exemplo GoDaddy, Locaweb, RegistroBR)',
+  'page--community-domain-create.step-dns-servers.second-paragraph': '2. Encontre a página de {dnsManager}, e altere os {serversName} para os servidores do Bonde:',
+  'page--community-domain-create.step-dns-servers.second-paragraph.dns-manager': 'gerenciador de DNS',
+  'page--community-domain-create.step-dns-servers.second-paragraph.servers-name': 'nomes de servidor',
+  'page--community-domain-create.step-dns-servers.button.text': 'Continuar',
+
+  'page--community-domain-create.step-check.title': 'Teste a conexão',
+  'page--community-domain-create.step-check.first-paragraph': 'Clique no botão abaixo para verificar se tudo está certo.',
+  'page--community-domain-create.step-check.second-paragraph': 'Atenção: a mudança de DNS pode demorar até 48 horas para ser propagada pela internet.',
+  'page--community-domain-create.step-check.button.text': 'Testar',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -544,4 +544,51 @@ export default {
   'widgets.components--form-autofire.form.email-subject.placeholder': 'Defina o assunto que irá aparecer na mensagem enviada.',
   'widgets.components--form-autofire.form.email-text.label': 'Email de agradecimento',
   'widgets.components--form-autofire.form.email-text.placeholder': 'Ex: Obrigado por apostar na força da ação coletiva em rede. Sua participação é muito importante e, agora, precisamos da sua ajuda para que mais gente colabore com esta mobilização. Compartilhe nas suas redes clicando em um dos links abaixo. Um abraço.',
+
+  // component widget form finish message
+  // filepath: /client/mobilizations/widgets/components/form-finish-message/index.js
+  'widgets.components--form-finish-message.success-message': 'Formulário salvo com sucesso!',
+  'widgets.components--form-finish-message.type.label': 'Tipo de mensagem',
+  'widgets.components--form-finish-message.type.radio.share': 'Compartilhar',
+  'widgets.components--form-finish-message.type.radio.custom': 'Customizar',
+  'widgets.components--form-finish-message.type.validation.required': 'Nenhum tipo de mensagem foi selecionado',
+  'widgets.components--form-finish-message.share.whatsapp-text.label': 'Texto do WhatsApp',
+  'widgets.components--form-finish-message.share.whatsapp-text.placeholder': 'Faça um texto curto, capaz de motivar outras pessoas a se unirem à sua mobilização. Você poderá alterar este texto depois.',
+  'widgets.components--form-finish-message.preview.label': 'Preview',
+  'widgets.components--form-finish-message.custom.message.default': 'Clique aqui para editar...',
+
+  // component share tell-a-friend
+  // filepath: /client/components/share/tell-a-friend.js
+  'share.components--tell-a-friend.text': 'Agora, compartilhe com seus amigos!',
+
+  // component share facebook-share-button
+  // filepath: /client/components/share/facebook-share-button.js
+  'share.components--facebook-share-button.text': 'Compartilhar no Facebook',
+
+  // component share twitter-share-button
+  // filepath: /client/components/share/twitter-share-button.js
+  'share.components--twitter-share-button.text': 'Compartilhar no Twitter',
+
+  // component share whatsapp-share-button
+  // filepath: /client/components/share/whatsapp-share-button.js
+  'share.components--whatsapp-share-button.text': 'Compartilhar no WhatsApp',
+
+  // page donation widget finish
+  // filepath: /routes/admin/authenticated/sidebar/widgets-donation-settings/finish/page.js
+  'page--donation-widget-finish.form.success-message': 'Formulário de pós-doação salvo com sucesso!',
+
+  // component donation widget tell-a-friend
+  // filepath: /client/mobilizations/widgets/__plugins__/donation/components/donation-tell-a-friend.js
+  'donation.components--tell-a-friend.message': 'Oba, doação registrada! Sua doação é via boleto? Verifique seu email.',
+
+  // config mobrender widgets
+  // filepath: /client/mobrender/widgets/config.js
+  'widgets.config--content.label': 'Texto',
+  'widgets.config--content.default': 'Clique aqui para editar...',
+  'widgets.config--form.label': 'Formulário',
+  'widgets.config--form.default': 'Obrigado por apostar na força da ação coletiva em rede. Sua participação é muito importante e, agora, precisamos da sua ajuda para que mais gente colabore com esta mobilização. Compartilhe nas suas redes clicando em um dos links abaixo.\n\nUm abraço',
+  'widgets.config--pressure.label': 'Pressão',
+  'widgets.config--pressure.default.title': 'Envie um e-mail para quem pode tomar essa decisão',
+  'widgets.config--pressure.default.button-text': 'Enviar e-mail',
+  'widgets.config--donation.label': 'Doação',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -337,4 +337,26 @@ export default {
   // page mobilizations templates choose global
   // filepath: /routes/admin/authenticated/sidebar/templates-choose-global/page.js
   'page--mobilizations.templates-choose-global.title': 'Templates Globais',
+
+  // component mobilizations settings menu
+  // filepath: /client/mobilizations/components/settings-menu.js
+  'mobilizations.components--settings-menu.title': 'Configure sua mobilização',
+  'mobilizations.components--settings-menu.tabs.info': 'Informações básicas',
+  'mobilizations.components--settings-menu.tabs.sharing': 'Compartilhamento',
+  'mobilizations.components--settings-menu.tabs.domain': 'Domínio',
+
+  // page mobilizations settings analytics
+  // filepath: /routes/admin/authenticated/sidebar/mobilizations-settings-analytics/page.js
+  'page--mobilizations-analytics.first-paragraph': 'Para acompanhar os resultados da sua mobilização, você precisa configurar uma conta no Google Analytics.',
+  'page--mobilizations-analytics.second-paragraph': 'Siga os passos abaixo:',
+  'page--mobilizations-analytics.ol.create-analytics-account': ' Crie uma conta no Google Analytics {link}',
+  'page--mobilizations-analytics.ol.create-analytics-account.link': 'clicando aqui',
+  'page--mobilizations-analytics.ol.keep-up-with': 'Obtenha sua ID de acompanhamento no Google Analytics. É um código que começa sempre com as letras UA, que você verá após criar sua conta lá.',
+  'page--mobilizations-analytics.ol.paste-ga-code': 'Copie a ID de acompanhamento e cole no campo abaixo:',
+  'page--mobilizations-analytics.ol.form.ga-code.label': 'ID do Google Analytics',
+  'page--mobilizations-analytics.ol.done': 'Pronto! Você já pode acompanhar as estatísticas da sua mobilização no Google Analytics!',
+
+  // page mobilizations settings analytics (connected)
+  // filepath: /routes/admin/authenticated/sidebar/mobilizations-settings-analytics/page.connected.js
+  'page--mobilizations-analytics.ol.form.ga-code.validation.invalid.ga-code.format': 'Informe uma ID válida',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -12,12 +12,18 @@ export default {
   'page--account-register.title': 'Crie sua conta no Bonde.',
   'page--account-register.form.name.label': 'Nome',
   'page--account-register.form.name.placeholder': 'Seu nome',
+  'page--account-register.form.name.validation.required': 'Informe seu nome',
   'page--account-register.form.lastname.label': 'Sobrenome',
   'page--account-register.form.lastname.placeholder': 'Sobrenome',
   'page--account-register.form.email.label': 'E-mail',
   'page--account-register.form.email.placeholder': 'exemplo@email.com.br',
+  'page--account-register.form.email.validation.required': 'Informe seu e-mail',
+  'page--account-register.form.email.validation.invalid-email-format': 'E-mail inválido',
   'page--account-register.form.password.label': 'Senha',
+  'page--account-register.form.password.label.validation.required': 'Informe uma senha',
+  'page--account-register.form.password.label.validation.min-length': 'Sua senha precisa ter um minímo de 8 caracteres.',
   'page--account-register.form.password-confirm.label': 'Confirme sua senha',
+  'page--account-register.form.password-confirm.label.validation.match': 'Senha não confere',
   'page--account-register.form.submit-button.default': 'Criar conta',
   'page--account-register.form.submit-button.saving': 'Salvando...',
 
@@ -96,6 +102,8 @@ export default {
   'community.components--subdomain-form.button.text': 'Adicionar',
 
   // page community domain
+  'page--community-domain.form.validation.required': 'Preenchimento obrigatório',
+
   'page--community-domain.section--dns-hosted-zone.title': 'Domínios da comunidade',
   'page--community-domain.section--dns-hosted-zone.add': 'Adicionar novo domínio',
   'page--community-domain.section--dns-hosted-zone.menu.subdomains': 'Subdomínios',
@@ -118,6 +126,8 @@ export default {
   'page--community-domain-create.step-add.title': 'Insira o domínio desejado',
   'page--community-domain-create.step-add.form.domain-name.label': 'Domínio da sua comunidade',
   'page--community-domain-create.step-add.form.domain-name.placeholder': 'Ex. minhacomunidade.org',
+  'page--community-domain-create.step-add.form.domain-name.validation.required': 'Domínio é obrigatório.',
+  'page--community-domain-create.step-add.form.domain-name.validation.invalid-domain-format': 'Domínio inválido',
   'page--community-domain-create.step-add.form.button.text': 'Adicionar',
 
   'page--community-domain-create.step-dns-servers.title': 'Altere os servidores do seu provedor DNS',
@@ -134,8 +144,15 @@ export default {
 
   // page community info
   'page--community-info.form.name.label': 'Nome',
+  'page--community-info.form.name.validation.required': 'Informe o nome da comunidade',
   'page--community-info.form.description.label': 'Descrição',
   'page--community-info.form.city.label': 'Cidade',
+  'page--community-info.form.city.validation.required': 'Informe em qual cidade sua comunidade atua',
   'page--community-info.form.custom-from-email.label': 'E-mail de resposta para notificações',
   'page--community-info.form.custom-from-email.helper-text': 'Você deve preencher seguindo o formato padrão: Nome do contato <contato@provedor.com>',
+  'page--community-info.form.custom-from-email.validation.invalid-email-format': 'E-mail de resposta fora do formato padrão',
+
+  // component settings form
+  'ux.components--settings-form.button.text': 'Salvar',
+  'ux.components--settings-form.success-message': 'Dados editados com sucesso',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -258,7 +258,13 @@ export default {
   'components.navigation--sidebar.mobilization-settings.item.open-at-new-tab': 'Ver em uma nova aba',
   'components.navigation--sidebar.mobilization-settings.item.config': 'Configurações',
 
+  'components.navigation--sidebar.footer.account': 'Minha Conta',
   'components.navigation--sidebar.footer.sign-out': 'Sair',
+
+  // component sidenav
+  // filepath: /client/components/navigation/sidenav/sidenav.js
+  'components.navigation--sidenav.config': 'Configurações',
+  'components.navigation--sidenav.change-community': 'Trocar',
 
   // page mobilizations list
   // filepath: /routes/admin/authenticated/sidebar/mobilizations-list/page.js
@@ -396,4 +402,27 @@ export default {
   'mobilizations.components--form-domain.cname-table.header.record-type': 'Tipo',
   'mobilizations.components--form-domain.cname-table.header.data': 'Dados',
   'mobilizations.components--form-domain.cname-table.footer.helper-text': 'Se tiver alguma dúvida, dá uma olhada no tópico "Configurando seu domínio no BONDE", no nosso tutorial, o {link}.',
+
+  // component mobrender mobilization
+  // filepath: /client/mobrender/components/mobilization.js
+  'mobrender.components--mobilization.footer.slogan': 'Feito pra causar. Feito com',
+
+  // component mobrender block config menu
+  // filepath: /client/mobrender/components/block-config-menu.js
+  'mobrender.components--block-config-menu.item.change-background': 'Alterar fundo',
+  'mobrender.components--block-config-menu.item.toggle-visibility.show': 'Mostrar',
+  'mobrender.components--block-config-menu.item.toggle-visibility.hide': 'Esconder',
+  'mobrender.components--block-config-menu.item.remove': 'Remover',
+  'mobrender.components--block-config-menu.item.remove.confirm': 'Você tem certeza que quer remover este bloco?',
+  'mobrender.components--block-config-menu.item.move-up': 'Mover para cima',
+  'mobrender.components--block-config-menu.item.move-down': 'Mover para baixo',
+
+  // component mobrender block change background
+  // filepath: /client/mobrender/components/block-change-background.js
+  'mobrender.components--block-change-background.button.save': 'Salvar',
+  'mobrender.components--block-change-background.button.cancel': 'Cancelar',
+
+  // component navigation navbar edition wrapper
+  // filepath: /client/components/navigation/navbar/navbar-edition-wrapper.js
+  'components.navigation--navbar-edition-wrapper.block': 'Bloco',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -1,5 +1,6 @@
 export default {
   // page account login
+  // filepath: /routes/admin/not-authenticated/account-login/page.js
   'page--account-login.label.email': 'E-mail',
   'page--account-login.label.password': 'Senha',
   'page--account-login.placeholder.email': 'exemplo@email.com',
@@ -9,6 +10,7 @@ export default {
   'page--account-login.cta-signup': 'Clique para criar uma conta.',
 
   // page account register
+  // filepath: /routes/admin/not-authenticated/account-register/page.js
   'page--account-register.title': 'Crie sua conta no Bonde.',
   'page--account-register.form.name.label': 'Nome',
   'page--account-register.form.name.placeholder': 'Seu nome',
@@ -28,6 +30,7 @@ export default {
   'page--account-register.form.submit-button.saving': 'Salvando...',
 
   // page account edit
+  // filepath: /routes/admin/authenticated/sidebar/account-edit/page.js
   'page--account-edit.header.title': 'Minha conta',
   'page--account-edit.header.tabs.user': 'Usuário',
   'page--account-edit.form.name.label': 'Nome',
@@ -37,12 +40,14 @@ export default {
   'page--account-edit.form.submit-button.success-message': 'Dados editados com sucesso.',
 
   // page subscription edit
+  // filepath: /routes/public/subscription-edit/page.js
   'page--subscription-edit.title': 'Dados da Doação',
   'page--subscription-edit.helper-text': 'Selecione abaixo qual informação da sua doação quer alterar:',
   'page--subscription-edit.button.creditcard': 'Cartão de crédito',
   'page--subscription-edit.button.recurring': 'Data da doação',
 
   // form subscription credit card
+  // filepath: /client/subscriptions/forms/credit-card-form.js
   'form--subscription-creditcard.helper-text': 'Altere os dados do seu cartão de crédito preenchendo os campos abaixo. Sua doação continuará a mesma mas, a partir do momento em que salvar os dados abaixo, o valor será cobrado neste novo cartão ; )',
 
   'form--subscription-creditcard.previous-data.title': 'Dados do último cartão',
@@ -61,6 +66,7 @@ export default {
   'form--subscription-creditcard.form.validation.required': 'Obrigatório',
 
   // form subscription recurring
+  // filepath: /client/subscriptions/forms/recurring-form.js
   'form--subscription-recurring.helper-text': 'Preencha os campos abaixo para alterar a data em que a cobrança da sua doação é efetuada. Sua doação continuará a mesma mas, a partir do momento em que salvar os dados abaixo, o valor será cobrado neste novo cartão ; )',
   'form--subscription-recurring.form.process-at.label': 'Nova data de cobrança',
   'form--subscription-recurring.form.process-at.placeholder': 'Ex: DD/MM/AAAA',
@@ -69,17 +75,20 @@ export default {
   'form--subscription-recurring.form.validation.invalid-date-format': 'Formato de data inválido',
 
   // notifications
+  // filepath: /client/utils/notifications.js
   'notification--generic-request-error.title': 'Ops!',
   'notification--generic-request-error.message': 'Parece que teve algum problema técnico nessa última requisição. Pedimos que tente de novo daqui a pouco.',
   'notification--generic-save-success.title': 'Oba!',
   'notification--generic-save-success.message': 'A requisição foi feita com sucesso e, os seus dados estão salvos em segurança.',
 
   // page community list
+  // filepath: /routes/admin/authenticated/external/community-list/page.js
   'page--community-list.title': 'Olá {userFirstName},',
   'page--community-list.subtitle': 'Escolha uma das suas comunidades',
   'page--community-list.new': 'Crie uma nova comunidade',
 
   // component community settings menu
+  // filepath: /client/community/components/settings-menu.js
   'community.components--settings-menu.title': 'Configurações da comunidade',
   'community.components--settings-menu.tabs.info': 'Informações',
   'community.components--settings-menu.tabs.mailchimp': 'Mailchimp',
@@ -88,20 +97,24 @@ export default {
   'community.components--settings-menu.tabs.domains': 'Domínios',
 
   // component community domain preview
+  // filepath: /client/community/components/dns/dns-preview/domain-preview.js
   'community.components--domain-preview.li.domain.header': 'Domínio da comunidade',
 
   // component community subdomain preview
+  // filepath: /client/community/components/dns/dns-preview/subdomain-preview.js
   'community.components--subdomain-preview.li.subdomain.header': 'Subdomínio',
   'community.components--subdomain-preview.li.record-type.header': 'Tipo',
   'community.components--subdomain-preview.li.redirect-to.header': 'Redirecionar para',
 
   // component community subdomain form
+  // filepath: /client/community/components/dns/subdomain-form/index.js
   'community.components--subdomain-form.subdomain.label': 'Subdomínio',
   'community.components--subdomain-form.record-type.label': 'Tipo',
   'community.components--subdomain-form.redirect-to.label': 'Redirecionar para',
   'community.components--subdomain-form.button.text': 'Adicionar',
 
   // page community domain
+  // filepath: /routes/admin/authenticated/sidebar/community-settings/domain/page.js
   'page--community-domain.form.validation.required': 'Preenchimento obrigatório',
 
   'page--community-domain.section--dns-hosted-zone.title': 'Domínios da comunidade',
@@ -117,10 +130,12 @@ export default {
   'page--community-domain.section--dns-records.menu.remove.dialog.text': 'Tem certeza que deseja remover o subdomínio {subdomainName}?',
 
   // component dialog
+  // filepath: /client/ux/components/dialog/index.js
   'ux.components--dialog.button.confirm.text': 'Confirmar',
   'ux.components--dialog.button.cancel.text': 'Cancelar',
 
-  // page community create
+  // page community domain create
+  // filepath: /routes/admin/authenticated/sidebar/community-settings/domain-create/page.js
   'page--community-domain-create.title': 'Domínio da comunidade',
 
   'page--community-domain-create.step-add.title': 'Insira o domínio desejado',
@@ -143,6 +158,7 @@ export default {
   'page--community-domain-create.step-check.button.text': 'Testar',
 
   // page community info
+  // filepath: /routes/admin/authenticated/sidebar/community-settings/info/page.js
   'page--community-info.form.name.label': 'Nome',
   'page--community-info.form.name.validation.required': 'Informe o nome da comunidade',
   'page--community-info.form.description.label': 'Descrição',
@@ -153,10 +169,12 @@ export default {
   'page--community-info.form.custom-from-email.validation.invalid-email-format': 'E-mail de resposta fora do formato padrão',
 
   // component settings form
+  // filepath: /client/ux/components/settings-form/index.js
   'ux.components--settings-form.button.text': 'Salvar',
   'ux.components--settings-form.success-message': 'Dados editados com sucesso',
 
   // page community mailchimp
+  // filepath: /routes/admin/authenticated/sidebar/community-settings/mailchimp/page.js
   'page--community-mailchimp.form.api-key.label': 'Mailchimp API Key',
   'page--community-mailchimp.form.list-id.label': 'Mailchimp ID da lista',
   'page--community-mailchimp.form.group-id.label': 'Mailchimp ID do grupo',

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -241,4 +241,22 @@ export default {
   'page--community-report.section-button.activists.title': 'RELATÓRIO DE ATIVISTAS',
   'page--community-report.section-button.activists.helper-text': 'Clique no botão abaixo para baixar o relatório dos ativistas da comunidade.',
   'page--community-report.section-button.activists.text': 'Baixar',
+
+  // component sidebar
+  // filepath: /client/components/navigation/sidebar/sidebar.js
+  'components.navigation--sidebar.community-settings.item.mobilizations': 'Minhas Mobilizações',
+  'components.navigation--sidebar.community-settings.item.info': 'Informações',
+  'components.navigation--sidebar.community-settings.item.mailchimp': 'Mailchimp',
+  'components.navigation--sidebar.community-settings.item.recipient': 'Recebedor',
+  'components.navigation--sidebar.community-settings.item.report': 'Relatório',
+  'components.navigation--sidebar.community-settings.item.domains': 'Domínios',
+
+  'components.navigation--sidebar.mobilization-settings.item.launch': 'PUBLICAR BONDE',
+  'components.navigation--sidebar.mobilization-settings.item.launched': 'BONDE público',
+  'components.navigation--sidebar.mobilization-settings.item.edit': 'Editar mobilização',
+  'components.navigation--sidebar.mobilization-settings.item.add-block': 'Adicionar conteúdo',
+  'components.navigation--sidebar.mobilization-settings.item.open-at-new-tab': 'Ver em uma nova aba',
+  'components.navigation--sidebar.mobilization-settings.item.config': 'Configurações',
+
+  'components.navigation--sidebar.footer.sign-out': 'Sair',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -440,4 +440,17 @@ export default {
   'mobilizations.components--form-share.twitter.helper-text': 'Configure a mensagem que será publicada no Twitter sempre que alguém compartilhar sua mobilização.',
   'mobilizations.components--form-share.twitter.form.share-text.label': 'Texto do Tweet',
   'mobilizations.components--form-share.twitter.form.share-text.placeholder': 'Insira uma frase e chame o leitor para a mobilização',
+
+  // page mobilizations launch
+  // filepath: /routes/admin/authenticated/sidebar/mobilizations-launch/page.js
+  'page--mobilizations-launch.title': 'Lançando sua mobilização',
+  'page--mobilizations-launch.steps.form-domain.title': 'Configure o endereço da mobilização',
+  'page--mobilizations-launch.steps.form-share.title': 'Configure as informações de compartilhamento',
+  'page--mobilizations-launch.steps.done.title': 'Seu BONDE está pronto!',
+  'page--mobilizations-launch.steps.done.helper-text': 'Em uma nova aba, digite o endereço que cadastrou na mobilização para se certificar de que ela já está no ar. Se ainda não estiver, cheque se cadastrou os domínios corretamente. Está tudo certo? Então é só esperar ele propagar pela internet!',
+  'page--mobilizations-launch.steps.done.button.open': 'Visualizar mobilização',
+  'page--mobilizations-launch.button.saving': 'Salvando...',
+  'page--mobilizations-launch.button.launch': 'Lançar mobilização',
+  'page--mobilizations-launch.button.next': 'Continuar',
+  'page--mobilizations-launch.form-share.validation.required': 'Obrigatório',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -178,4 +178,21 @@ export default {
   'page--community-mailchimp.form.api-key.label': 'Mailchimp API Key',
   'page--community-mailchimp.form.list-id.label': 'Mailchimp ID da lista',
   'page--community-mailchimp.form.group-id.label': 'Mailchimp ID do grupo',
+
+  // page community new
+  // filepath: /routes/admin/authenticated/external/community-new/page.js
+  'page--community-new.title': 'Crie uma comunidade',
+  'page--community-new.subtitle': 'Comunidades do Bonde são grupos de ação que trabalham juntos por uma causa.',
+
+  'page--community-new.form.name.label': 'Nome da comunidade',
+  'page--community-new.form.name.placeholder': 'Exemplo: Movimento 90º São Paulo',
+  'page--community-new.form.city.label': 'Cidade da comunidade',
+  'page--community-new.form.city.placeholder': 'Exemplo: São Paulo',
+  'page--community-new.form.submit-button.text.default': 'Criar comunidade',
+  'page--community-new.form.submit-button.text.saving': 'Salvando...',
+
+  // page community new (connected)
+  // filepath: /routes/admin/authenticated/external/community-new/page.connected.js
+  'page--community-new.form.name.validation.required': 'Informe o nome da comunidade',
+  'page--community-new.form.city.validation.required': 'Informe em qual cidade sua comunidade atua',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -613,13 +613,13 @@ export default {
 
   // page form widget
   // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/form/page.js
-  'widgets.components--form.form.success-message': 'Formulário configurado com sucesso!',
-  'widgets.components--form.form.widget-title.label': 'Título do formulário',
-  'widgets.components--form.form.widget-title.placeholder': 'Ex: Preencha o formulário abaixo para assinar a petição.',
-  'widgets.components--form.form.button-text.label': 'Botão',
-  'widgets.components--form.form.button-text.placeholder': 'Defina o texto do botão de confirmação do formulário.',
-  'widgets.components--form.form.counter-text.label': 'Contador',
-  'widgets.components--form.form.counter-text.placeholder': 'Defina o texto que ficará ao lado do número de pessoas que agiram.',
+  'page--form-widget.form.success-message': 'Formulário configurado com sucesso!',
+  'page--form-widget.form.widget-title.label': 'Título do formulário',
+  'page--form-widget.form.widget-title.placeholder': 'Ex: Preencha o formulário abaixo para assinar a petição.',
+  'page--form-widget.form.button-text.label': 'Botão',
+  'page--form-widget.form.button-text.placeholder': 'Defina o texto do botão de confirmação do formulário.',
+  'page--form-widget.form.counter-text.label': 'Contador',
+  'page--form-widget.form.counter-text.placeholder': 'Defina o texto que ficará ao lado do número de pessoas que agiram.',
 
   // component data export
   // filepath: /client/mobilizations/widgets/components/data-export.js
@@ -633,4 +633,51 @@ export default {
   // action async widget data export
   // filepath: /client/mobrender/redux/action-creators/async-widget-data-export.js
   'action--async-widget-data-export.no-data': 'Nao foi encontrado nenhum dado para ser exportado',
+
+  // page form widget fields
+  // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/fields/page.js
+  'page--form-widget-fields.add-button': 'Adicionar um campo',
+  'page--form-widget-fields.helper-text.still-empty': 'Seu formulário ainda não possui nenhum campo. Clique abaixo para começar a adicionar campos.',
+  'page--form-widget-fields.helper-text.manage-fields': 'Adicione, remova, edite e ordene os campos do formulário de acordo com as necessidades da sua ação.',
+
+  // component form widget
+  // filepath: /client/mobilizations/widgets/__plugins__/form/components/__form__.js
+  'form-widget.components--form.default.title-text': 'Clique para configurar seu formulário...',
+  'form-widget.components--form.default.button-text': 'Enviar',
+  'form-widget.components--form.default.counter-suffix': 'assinaturas',
+
+  // component form widget input
+  // filepath: /client/mobilizations/widgets/__plugins__/form/components/input.js
+  'form-widget.components--input.click-to-edit': 'Clique para editar',
+  'form-widget.components--input.field-dropdown.options.default': 'Selecione...',
+  'form-widget.components--input.field-greetings.title': 'Mensagem de sucesso alterada para:',
+
+  // component form widget input form
+  // filepath: /client/mobilizations/widgets/__plugins__/form/components/input-form.js
+  'form-widget.components--input-form.handle-remove.confirm': 'Você tem certeza que quer remover este campo?',
+  'form-widget.components--input-form.handle-overlay-click.confirm': 'Ao sair sem salvar você perderá suas modificações. Deseja sair sem salvar?',
+  'form-widget.components--input-form.field-title.label': 'Título do campo',
+  'form-widget.components--input-form.field-title.placeholder': 'Ex: Email',
+  'form-widget.components--input-form.field-helper-text.label': 'Texto de ajuda',
+  'form-widget.components--input-form.field-helper-text.placeholder': 'Ex: Insira aqui o seu email',
+  'form-widget.components--input-form.field-type.label': 'Tipo de campo',
+  'form-widget.components--input-form.field-type.options.text': 'Texto',
+  'form-widget.components--input-form.field-type.options.email': 'E-mail',
+  'form-widget.components--input-form.field-type.options.number': 'Número',
+  'form-widget.components--input-form.field-type.options.dropdown': 'Dropdown &#9733;',
+  'form-widget.components--input-form.field-type.options.greetings': 'Saudação &#9733;',
+  'form-widget.components--input-form.field-required.label': 'Obrigatório',
+  'form-widget.components--input-form.field-required.radio.yes.label': 'Sim',
+  'form-widget.components--input-form.field-required.radio.no.label': 'Não',
+  'form-widget.components--input-form.button-move-up': 'Mover para cima',
+  'form-widget.components--input-form.button-move-down': 'Mover para baixo',
+  'form-widget.components--input-form.button-remove': 'Remover',
+  'form-widget.components--input-form.button-cancel': 'Cancelar',
+  'form-widget.components--input-form.button-save.saving': 'Salvando...',
+  'form-widget.components--input-form.button-save.default': 'Salvar',
+
+  // component mobrender widget overlay
+  // filepath: /client/mobrender/components/widget-overlay.js
+  'mobrender.components--widget-overlay.button.edit.title': 'Editar',
+  'mobrender.components--widget-overlay.button.remove.title': 'Remover',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -743,4 +743,57 @@ export default {
   // component pressure widget tell a friend
   // filepath: /client/mobilizations/widgets/__plugins__/pressure/components/pressure-tell-a-friend.js
   'pressure-widget--tell-a-friend.message': 'Pressão enviada',
+
+  //
+  // page activists management
+  // filepath: {incoming-for-v0.6.x release}
+  //
+  // if the namenclature of the items was not matching when implementing
+  // this feature, consider to make the necessary changes. after it,
+  // remove this comment and place the respective filepath of the
+  // translation keys.
+  //
+  // maybe, new intl key name convention can be implemented.
+  //   e.g.
+  //   - page      ~> `p--`
+  //   - component ~> `c--`
+  //
+  'p--activists-management.header.title': 'Base de usuários',
+  'p--activists-management.header.button.upload.text': 'Upload',
+  'p--activists-management.header.button.download.text': 'Download',
+  'p--activists-management.content.title': '{totalNumber} pessoas',
+  'p--activists-management.content.button.tagging.text': 'Etiquetar',
+  'p--activists-management.content.button.email.text': 'Email',
+  'p--activists-management.content.form-tagging.tags.placeholder': 'Digite tags separadas por vírgula',
+  'p--activists-management.content.form-tagging.button.text': 'Adicionar etiqueta',
+  'p--activists-management.content.form-tagging.success.message': 'Etiquetas adicionadas com sucesso a {taggedNumber} pessoas',
+  'p--activists-management.content.form-tagging.success.undo': 'Desfazer',
+  'p--activists-management.content.activist-spotlight.title': 'Perfil selecionado',
+  'p--activists-management.content.activist-spotlight.email.label': 'Email',
+  'p--activists-management.content.activist-spotlight.phone.label': 'Telefone',
+  'p--activists-management.content.activist-spotlight.mobilizations.label': 'Mobilizações',
+  'p--activists-management.content.activist-spotlight.tags.label': 'Etiquetas',
+  'p--activists-management.content.activist-spotlight.form-tagging.button.text': 'Adicionar',
+
+  // component activists management filterable list
+  // filepath: {incoming-for-v0.6.x release}
+  'activists-management.c--filterable-list.activist.placeholder': 'Quem você está procurando?',
+
+  'activists-management.c--filterable-list.suggest.placeholder': 'Filtre por mobilizações ou formulários',
+  'activists-management.c--filterable-list.suggest.operators.label': 'Operadores',
+  'activists-management.c--filterable-list.suggest.operators.options.or.label': 'ou',
+  'activists-management.c--filterable-list.suggest.operators.options.and.label': 'e',
+  'activists-management.c--filterable-list.suggest.segment.donations.label': 'Doações',
+  'activists-management.c--filterable-list.suggest.segment.pressures.label': 'Pressões',
+  'activists-management.c--filterable-list.suggest.segment.gen-forms.label': 'Formulários genéricos',
+  'activists-management.c--filterable-list.suggest.segment.other-tags.label': 'Outras etiquetas',
+
+  'activists-management.c--filterable-list.period.options.today': 'Hoje',
+  'activists-management.c--filterable-list.period.options.last-week': 'Na última semana',
+  'activists-management.c--filterable-list.period.options.last-fortnight': 'Nos últimos 15 dias',
+  'activists-management.c--filterable-list.period.options.last-month': 'Nos últimos 30 dias',
+  'activists-management.c--filterable-list.period.options.last-quarter': 'Nos últimos 3 meses',
+  'activists-management.c--filterable-list.period.options.last-year': 'No último ano',
+  'activists-management.c--filterable-list.period.options.always': 'Sempre',
+  'activists-management.c--filterable-list.period.options.custom-period': 'Customizar período...',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -89,6 +89,12 @@ export default {
   'community.components--subdomain-preview.li.record-type.header': 'Tipo',
   'community.components--subdomain-preview.li.redirect-to.header': 'Redirecionar para',
 
+  // component community subdomain form
+  'community.components--subdomain-form.subdomain.label': 'Subdomínio',
+  'community.components--subdomain-form.record-type.label': 'Tipo',
+  'community.components--subdomain-form.redirect-to.label': 'Redirecionar para',
+  'community.components--subdomain-form.button.text': 'Adicionar',
+
   // page community domain
   'page--community-domain.section--dns-hosted-zone.title': 'Domínios da comunidade',
   'page--community-domain.section--dns-hosted-zone.add': 'Adicionar novo domínio',
@@ -125,4 +131,6 @@ export default {
   'page--community-domain-create.step-check.first-paragraph': 'Clique no botão abaixo para verificar se tudo está certo.',
   'page--community-domain-create.step-check.second-paragraph': 'Atenção: a mudança de DNS pode demorar até 48 horas para ser propagada pela internet.',
   'page--community-domain-create.step-check.button.text': 'Testar',
+
+
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -195,4 +195,36 @@ export default {
   // filepath: /routes/admin/authenticated/external/community-new/page.connected.js
   'page--community-new.form.name.validation.required': 'Informe o nome da comunidade',
   'page--community-new.form.city.validation.required': 'Informe em qual cidade sua comunidade atua',
+
+  // page community recipient
+  // filepath: /routes/admin/authenticated/sidebar/community-settings/recipient/page.js
+  'page--community-recipient.form.transfer-interval.label': 'Intervalo',
+  'page--community-recipient.form.transfer-interval.value.weekly': 'Semanalmente',
+  'page--community-recipient.form.transfer-interval.value.monthly': 'Mensalmente',
+  'page--community-recipient.form.transfer-day.label': 'Dia de transferência',
+
+  'page--community-recipient.section--account.header': 'Conta bancária',
+  'page--community-recipient.form.bank-code.label': 'Banco',
+  'page--community-recipient.form.bank-code.value.default': 'Selecione o banco',
+  'page--community-recipient.form.bank-account-type.label': 'Tipo de conta',
+  'page--community-recipient.form.bank-account-type.value.checking-account': 'Corrente',
+  'page--community-recipient.form.bank-account-type.value.savings-account': 'Poupança',
+  'page--community-recipient.form.bank-agency.label': 'Agência',
+  'page--community-recipient.form.bank-agency-dv.label': 'Dígito',
+  'page--community-recipient.form.bank-account.label': 'Conta',
+  'page--community-recipient.form.bank-account-dv.label': 'Dígito',
+  'page--community-recipient.form.bank-legal-name.label': 'Nome / Razão Social',
+  'page--community-recipient.form.bank-document-number.label': 'CPF / CNPJ',
+
+  // page community recipient (connected)
+  // filepath: /routes/admin/authenticated/sidebar/community-settings/recipient/page.connected.js
+  'page--community-recipient.form.validation.required': 'Campo obrigatório',
+  'page--community-recipient.form.bank-agency.validation.max-length': 'Deve conter no máximo 5 digitos',
+  'page--community-recipient.form.bank-agency-dv.validation.length': 'Deve conter apenas 1 digito',
+  'page--community-recipient.form.bank-account.validation.max-length': 'Deve conter no máximo 13 digitos',
+  'page--community-recipient.form.bank-account-dv.validation.max-length': 'Deve conter no máximo 2 caracteres',
+  'page--community-recipient.form.bank-document-number.validation.cnpj-length': 'CNPJ deve conter 14 digitos',
+  'page--community-recipient.form.bank-document-number.validation.cpf-length': 'CPF deve conter 11 digitos',
+  'page--community-recipient.form.bank-document-number.validation.invalid-cpf-format': 'CPF inválido',
+  'page--community-recipient.form.bank-document-number.validation.invalid-cnpj-format': 'CNPJ inválido',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -460,4 +460,14 @@ export default {
   'page--mobilizations-launch-end.heading.just-launch': 'Agora é só lançar e contar pra todo mundo!',
   'page--mobilizations-launch-end.title': 'Chegou a hora',
   'page--mobilizations-launch-end.button': 'Lançar mobilização',
+
+  // page templates list
+  // filepath: /routes/admin/authenticated/sidebar/templates-list/page.js
+  'page--templates-list.header.title': 'Seus templates',
+  'page--templates-list.empty-list.no-template': 'Nenhum template criado.',
+  'page--templates-list.empty-list.create-one': 'Crie a partir de uma mobilização.',
+  'page--templates-list.empty-list.mobilization-list': 'Lista de mobilizações',
+  'page--templates-list.more-menu-action.remove.text': 'Remover',
+  'page--templates-list.more-menu-action.remove.confirm': 'Tem certeza que deseja remover este template? Ao confirmar, não é possível desfazer esta ação.',
+  'page--templates-list.more-menu-action.remove.confirm': 'Tem certeza que deseja remover este template? Ao confirmar, não é possível desfazer esta ação.',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -35,4 +35,20 @@ export default {
   'page--subscription-edit.helper-text': 'Selecione abaixo qual informação da sua doação quer alterar:',
   'page--subscription-edit.button.creditcard': 'Cartão de crédito',
   'page--subscription-edit.button.recurring': 'Data da doação',
+
+  // form subscription credit card
+  'form--subscription-creditcard.helper-text': 'Altere os dados do seu cartão de crédito preenchendo os campos abaixo. Sua doação continuará a mesma mas, a partir do momento em que salvar os dados abaixo, o valor será cobrado neste novo cartão ; )',
+  'form--subscription-creditcard.previous-data.title': 'Dados do último cartão',
+  'form--subscription-creditcard.previous-data.name': 'Nome',
+  'form--subscription-creditcard.previous-data.expiration-date': 'Validade',
+  'form--subscription-creditcard.form.number.label': 'Número',
+  'form--subscription-creditcard.form.number.placeholder': 'Ex: 0000 0000 0000 0000',
+  'form--subscription-creditcard.form.name.label': 'Nome',
+  'form--subscription-creditcard.form.name.placeholder': '(igual ao que aparece no cartão)',
+  'form--subscription-creditcard.form.expiration-date.label': 'Validade',
+  'form--subscription-creditcard.form.expiration-date.placeholder': '00/00',
+  'form--subscription-creditcard.form.cvv.label': 'CVV',
+  'form--subscription-creditcard.form.cvv.placeholder': 'Ex: 000',
+  'form--subscription-creditcard.form.submit-button.text': 'Salvar',
+  'form--subscription-creditcard.form.validation.required': 'Obrigatório',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -453,4 +453,11 @@ export default {
   'page--mobilizations-launch.button.launch': 'Lançar mobilização',
   'page--mobilizations-launch.button.next': 'Continuar',
   'page--mobilizations-launch.form-share.validation.required': 'Obrigatório',
+
+  // page mobilizations launch end
+  // filepath: /routes/admin/authenticated/sidebar/mobilizations-launch-end/page.js
+  'page--mobilizations-launch-end.heading.all-done': 'Tudo pronto?',
+  'page--mobilizations-launch-end.heading.just-launch': 'Agora é só lançar e contar pra todo mundo!',
+  'page--mobilizations-launch-end.title': 'Chegou a hora',
+  'page--mobilizations-launch-end.button': 'Lançar mobilização',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -1,4 +1,5 @@
 export default {
+  // page account login
   'page--account-login.label.email': 'E-mail',
   'page--account-login.label.password': 'Senha',
   'page--account-login.placeholder.email': 'exemplo@email.com',
@@ -6,4 +7,17 @@ export default {
   'page--account-login.signin': 'Entrar',
   'page--account-login.ask-register': 'Ainda não é cadastrado?',
   'page--account-login.cta-signup': 'Clique para criar uma conta.'
+
+  // page account register
+  'page--account-register.title': 'Crie sua conta no Bonde.',
+  'page--account-register.form.name.label': 'Nome',
+  'page--account-register.form.name.placeholder': 'Seu nome',
+  'page--account-register.form.lastname.label': 'Sobrenome',
+  'page--account-register.form.lastname.placeholder': 'Sobrenome',
+  'page--account-register.form.email.label': 'E-mail',
+  'page--account-register.form.email.placeholder': 'exemplo@email.com.br',
+  'page--account-register.form.password.label': 'Senha',
+  'page--account-register.form.password-confirm.label': 'Confirme sua senha',
+  'page--account-register.form.submit-button.default': 'Criar conta',
+  'page--account-register.form.submit-button.saving': 'Salvando...',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -59,4 +59,10 @@ export default {
   'form--subscription-recurring.form.submit-button.text': 'Salvar',
   'form--subscription-recurring.form.validation.required': 'Obrigatório',
   'form--subscription-recurring.form.validation.invalid-date-format': 'Formato de data inválido',
+
+  // notifications
+  'notification--generic-request-error.title': 'Ops!',
+  'notification--generic-request-error.message': 'Parece que teve algum problema técnico nessa última requisição. Pedimos que tente de novo daqui a pouco.',
+  'notification--generic-save-success.title': 'Oba!',
+  'notification--generic-save-success.message': 'A requisição foi feita com sucesso e, os seus dados estão salvos em segurança.',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -591,4 +591,14 @@ export default {
   'widgets.config--pressure.default.title': 'Envie um e-mail para quem pode tomar essa decisão',
   'widgets.config--pressure.default.button-text': 'Enviar e-mail',
   'widgets.config--donation.label': 'Doação',
+
+  // component donation widget
+  // filepath: /client/mobilizations/widgets/__plugins__/donation/components/__donation__/index.js
+  'widgets.components--donation.default.button-text': 'Doar agora',
+  'widgets.components--donation.default.title-text': 'Clique para configurar seu bloco de doação',
+  'widgets.components--donation.period-label-options.month': 'mês',
+  'widgets.components--donation.period-label-options.halfyear': 'semestre',
+  'widgets.components--donation.period-label-options.year': 'ano',
+  'widgets.components--donation.users-choice.recurring': 'Apoiar todo {periodLabelCurrent}',
+  'widgets.components--donation.users-choice.unique': 'Doação única',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -259,4 +259,33 @@ export default {
   'components.navigation--sidebar.mobilization-settings.item.config': 'Configurações',
 
   'components.navigation--sidebar.footer.sign-out': 'Sair',
+
+  // page mobilizations list
+  // filepath: /routes/admin/authenticated/sidebar/mobilizations-list/page.js
+  'page--mobilizations-list.page-header.title': 'Suas Mobilizações',
+  'page--mobilizations-list.more-menu-action.open': 'Abrir página',
+  'page--mobilizations-list.more-menu-action.create-template': 'Criar template',
+
+  // component mobilizations page header
+  // filepath: /client/mobilizations/components/page-header.js
+  'mobilizations.components--page-header.button.text': 'Nova mobilização',
+  'mobilizations.components--tabs.actives': 'Ativas',
+  'mobilizations.components--tabs.templates': 'Templates',
+
+  // component mobilizations list item: name
+  // filepath: /client/mobilizations/components/list/items/name/index.js
+  'mobilizations.components--list.items.name.header.text': 'Nome',
+
+  // component mobilizations list item: created at
+  // filepath: /client/mobilizations/components/list/items/created-at.js
+  'mobilizations.components--list.items.created-at.header.text': 'Criada em',
+
+  // component mobilizations list item: users
+  // filepath: /client/mobilizations/components/list/items/users.js
+  'mobilizations.components--list.items.users.header.text': 'Usuários',
+
+  // component mobilizations list item: fund raising
+  // filepath: /client/mobilizations/components/list/items/fund-raising.js
+  'mobilizations.components--list.items.fund-raising.header.text': 'Arrecadações',
+  'mobilizations.components--list.items.fund-raising.currency': 'R$',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -288,4 +288,26 @@ export default {
   // filepath: /client/mobilizations/components/list/items/fund-raising.js
   'mobilizations.components--list.items.fund-raising.header.text': 'Arrecadações',
   'mobilizations.components--list.items.fund-raising.currency': 'R$',
+
+  // component mobilizations page tab layout
+  // filepath: /client/mobilizations/components/page-tab-layout.js
+  'mobilizations.components--page-tab-layout.title': 'Nova mobilização',
+  'mobilizations.components--tabs.goal': 'Objetivo',
+  'mobilizations.components--tabs.templates': 'Templates',
+
+  // page mobilizations new
+  // filepath: /routes/admin/authenticated/sidebar/mobilizations-new/page.js
+  'page--mobilizations-new.title': 'Qual o objetivo da sua mobilização?',
+  'page--mobilizations-new.footer': 'Fique tranquil@ vc poderá editar depois se achar necessário.',
+
+  // component mobilizations mobilization basics form
+  // filepath: /client/mobilizations/components/mobilization-basics-form.js
+  'mobilizations.components--basics-form.name.label': 'Nome',
+  'mobilizations.components--basics-form.name.placeholder': 'Ex: Pela criação de uma delegacia de desaparecidos',
+  'mobilizations.components--basics-form.name.validation.required': 'Insira o nome da mobilização',
+  'mobilizations.components--basics-form.name.validation.max-length': 'Seu título está muito longo!',
+  'mobilizations.components--basics-form.goal.label': 'Objetivo',
+  'mobilizations.components--basics-form.goal.placeholder': 'Faça um texto curto, capaz de motivar outras pessoas a se unirem à sua mobilização. Você poderá alterar este texto depois.',
+  'mobilizations.components--basics-form.goal.validation.required': 'Insira o objetivo da mobilização',
+  'mobilizations.components--basics-form.goal.validation.max-length': 'O limite de caracteres foi atingido.',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -310,4 +310,9 @@ export default {
   'mobilizations.components--basics-form.goal.placeholder': 'Faça um texto curto, capaz de motivar outras pessoas a se unirem à sua mobilização. Você poderá alterar este texto depois.',
   'mobilizations.components--basics-form.goal.validation.required': 'Insira o objetivo da mobilização',
   'mobilizations.components--basics-form.goal.validation.max-length': 'O limite de caracteres foi atingido.',
+
+  // component control buttons
+  // filepath: /client/components/forms/control-buttons.js
+  'components--control-buttons.input.value.default': 'Continuar',
+  'components--control-buttons.input.value.saving': 'Salvando...',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -369,4 +369,31 @@ export default {
   'page--block-create.background.label': 'Fundo',
   'page--block-create.background.image.placeholder.text': 'Selecione a imagem de fundo',
   'page--block-create.button-add.text': 'Adicionar',
+
+  // page mobilizations domain
+  // filepath: /routes/admin/authenticated/sidebar/mobilizations-settings-domain/page.js
+  'page--mobilizations-domain.form-domain.success-message': 'Dados de domínio salvos com sucesso',
+
+  // component mobilizations form domain
+  // filepath: /client/mobilizations/components/form-domain.js
+  'mobilizations.components--form-domain.basic.header-toggle.use-existing-domain': 'Quero usar o domínio principal da minha comunidade',
+  'mobilizations.components--form-domain.basic.header-toggle.create-domain': 'Quero cadastrar um domínio principal na minha comunidade',
+  'mobilizations.components--form-domain.basic.helper-text': 'Preencha abaixo o subdomínio e escolha o domínio que deseja configurar como endereço da sua mobilização',
+  'mobilizations.components--form-domain.basic.form.subdomain.label': 'Subdomínio',
+  'mobilizations.components--form-domain.basic.form.subdomain.placeholder': 'nomedamob',
+  'mobilizations.components--form-domain.basic.form.domain.label': 'Domínio Principal',
+  'mobilizations.components--form-domain.basic.create-domain.helper-text': 'Ops, você ainda não tem um domínio configurado na sua comunidade. Se quiser cadastar, {link}. Senão você pode, abaixo, usar um domínio externo para configurar o endereço da sua mobilização.',
+  'mobilizations.components--form-domain.basic.create-domain.helper-text.link': 'clique aqui',
+
+  'mobilizations.components--form-domain.advanced.header-toggle': 'Quero usar um domínio externo',
+  'mobilizations.components--form-domain.advanced.helper-text': 'Se você quer usar um domínio que comprou mas não está cadastrado na sua comunidade aqui, pode fazer isso. Por exemplo, se você já comprou www.meudominio.com.br você pode usá-lo para este BONDE. Demais, né? Preencha o campo abaixo e siga as orientações:',
+  'mobilizations.components--form-domain.advanced.form.external-domain.label': 'Domínio personalizado',
+  'mobilizations.components--form-domain.advanced.form.external-domain.placeholder': 'meudominio.com.br',
+
+  'mobilizations.components--form-domain.cname-table.helper-text': '{strong}: você vai precisar configurar este domínio no seu servidor de registro para que o endereço seja redirecionado à página da sua mobilização. Pra isso, você vai precisar dessas informações aqui embaixo, anote aí:',
+  'mobilizations.components--form-domain.cname-table.helper-text.strong': 'Não esqueça',
+  'mobilizations.components--form-domain.cname-table.header.name': 'Nome',
+  'mobilizations.components--form-domain.cname-table.header.record-type': 'Tipo',
+  'mobilizations.components--form-domain.cname-table.header.data': 'Dados',
+  'mobilizations.components--form-domain.cname-table.footer.helper-text': 'Se tiver alguma dúvida, dá uma olhada no tópico "Configurando seu domínio no BONDE", no nosso tutorial, o {link}.',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -29,4 +29,10 @@ export default {
   'page--account-edit.form.email.label': 'E-mail',
   'page--account-edit.form.submit-button.default': 'Salvar',
   'page--account-edit.form.submit-button.success-message': 'Dados editados com sucesso.',
+
+  // page subscription edit
+  'page--subscription-edit.title': 'Dados da Doação',
+  'page--subscription-edit.helper-text': 'Selecione abaixo qual informação da sua doação quer alterar:',
+  'page--subscription-edit.button.creditcard': 'Cartão de crédito',
+  'page--subscription-edit.button.recurring': 'Data da doação',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -478,4 +478,56 @@ export default {
   'page--templates-create.form.name.placeholder': 'Pela criação de uma delegacia de desaparecidos',
   'page--templates-create.form.goal.label': 'Descrição',
   'page--templates-create.form.goal.placeholder': 'Faça um texto curto, capaz de motivar outras pessoas a se unirem à sua mobilização. Você poderá alterar este texto depois.',
+
+  // component donation widget settings menu
+  // filepath: /client/mobilizations/widgets/__plugins__/donation/components/settings-menu.js
+  'donation.components--settings-menu.title': 'Configure o bloco de doação',
+  'donation.components--settings-menu.tabs.adjusts': 'Ajustes',
+  'donation.components--settings-menu.tabs.autofire': 'Mensagem agradecimento',
+  'donation.components--settings-menu.tabs.post-action': 'Pós-doação',
+
+  // page donation widget
+  // filepath: /routes/admin/authenticated/sidebar/widgets-donation-settings/donation/page.js
+  'page--donation-widget.header.title': 'Crie um template a partir da mobilização',
+  'page--donation-widget.form.submit-button': 'Salvar',
+  'page--donation-widget.form.success-message': 'Formulário de doação configurado com sucesso!',
+  'page--donation-widget.form.donation-title.label': 'Título do bloco de doação',
+  'page--donation-widget.form.donation-title.placeholder': 'Ex.: Escolha um valor e contribua agora!',
+  'page--donation-widget.form.payment-type.label': 'Tipo de doação',
+  'page--donation-widget.form.payment-type.unique': 'Única',
+  'page--donation-widget.form.payment-type.recurring': 'Recorrente',
+  'page--donation-widget.form.payment-type.users-choice': 'Usuário escolhe',
+  'page--donation-widget.form.payment-interval.label': 'Intervalo da recorrência',
+  'page--donation-widget.form.payment-interval.monthly': 'Mensal',
+  'page--donation-widget.form.payment-interval.semiannually': 'Semestral',
+  'page--donation-widget.form.payment-interval.annually': 'Anual',
+  'page--donation-widget.form.main-color.label': 'Defina a cor da página de pagamento',
+  'page--donation-widget.form.main-color.helper-text': 'Selecione a cor no box abaixo ou insira o valor em hex, por exemplo: #DC3DCE.',
+  'page--donation-widget.form.donation-default-value.label': 'Defina os valores para o bloco de doação',
+  'page--donation-widget.form.donation-default-value.helper-text': 'Você pode ter até 5 valores por bloco de doação. Preencha apenas com números inteiros (Ex: 50)',
+  'page--donation-widget.form.default-value-01.label': 'Valor 1',
+  'page--donation-widget.form.default-value-01.placeholder': 'R$20',
+  'page--donation-widget.form.default-value-02.label': 'Valor 2',
+  'page--donation-widget.form.default-value-02.placeholder': 'R$50',
+  'page--donation-widget.form.default-value-03.label': 'Valor 3',
+  'page--donation-widget.form.default-value-03.placeholder': 'R$100',
+  'page--donation-widget.form.default-value-04.label': 'Valor 4',
+  'page--donation-widget.form.default-value-04.placeholder': 'R$200',
+  'page--donation-widget.form.default-value-05.label': 'Valor 5',
+  'page--donation-widget.form.default-value-05.placeholder': 'R$500',
+  'page--donation-widget.form.default-value.radio.text': 'Default',
+  'page--donation-widget.form.default-value.helper-text': '*todos os valores são em reais',
+  'page--donation-widget.form.button-text.label': 'Texto do botão de doação',
+  'page--donation-widget.form.button-text.placeholder': 'Ex.: Doe agora!',
+  'page--donation-widget.form.payment-method.label': 'Habilitar pagamento por boleto?',
+  'page--donation-widget.form.payment-method.helper-text': 'Cada boleto pago terá um custo adicional de R$3,00',
+  'page--donation-widget.form.payment-method.radio.yes': 'Sim',
+  'page--donation-widget.form.payment-method.radio.no': 'Não',
+  'page--donation-widget.form.bank-account.label': 'Conta bancária',
+  'page--donation-widget.form.bank-account.helper-text': 'Este bloco de doação está associado à conta correspondente da cidade no Pagar.me.',
+
+  // page donation widget (connected)
+  // filepath: /routes/admin/authenticated/sidebar/widgets-donation-settings/donation/page.connected.js
+  'page--donation-widget.form.validation.button-text.required': 'Insira o texto do botão',
+  'page--donation-widget.form.validation.button-text.max-length': 'O limite de caracteres foi atingido.',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -688,4 +688,34 @@ export default {
   // component form widget tell a friend
   // filepath: /client/mobilizations/widgets/__plugins__/form/components/form-tell-a-friend.js
   'form-widget.components--tell-a-friend.message': 'Formulário submetido com sucesso!',
+
+  // component pressure widget settings menu
+  // filepath: /client/mobilizations/widgets/__plugins__/pressure/components/settings-menu.js
+  'pressure-widget.components--settings-menu.title': 'Configure seu formulário de pressão',
+  'pressure-widget.components--settings-menu.items.form': 'Formulário',
+  'pressure-widget.components--settings-menu.items.pressure-email': 'E-mail para alvo',
+  'pressure-widget.components--settings-menu.items.autofire': 'Mensagem de agradecimento',
+  'pressure-widget.components--settings-menu.items.post-action': 'Pós-pressão',
+
+  // page pressure widget
+  // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/finish/page.js
+  'page--pressure-widget.success-message': 'Formulário de pressão configurado com sucesso!',
+  'page--pressure-widget.form.title-text.label': 'Título do formulário',
+  'page--pressure-widget.form.title-text.placeholder': 'Envie um e-mail para quem pode tomar essa decisão',
+  'page--pressure-widget.form.button-text.label': 'Texto do botão',
+  'page--pressure-widget.form.button-text.placeholder': 'Enviar e-mail',
+  'page--pressure-widget.form.main-color.label': 'Cor do formulário',
+  'page--pressure-widget.form.show-counter.label': 'Mostrar contador de pressão',
+  'page--pressure-widget.form.show-counter.radio.yes.label': 'Sim',
+  'page--pressure-widget.form.show-counter.radio.no.label': 'Não',
+  'page--pressure-widget.form.counter-text.label': 'Texto do contador',
+  'page--pressure-widget.form.counter-text.placeholder': 'pressões feitas',
+  'page--pressure-widget.form.show-city-field.label': 'Mostrar campo de cidade',
+  'page--pressure-widget.form.show-city-field.radio.yes.label': 'Sim',
+  'page--pressure-widget.form.show-city-field.radio.no.label': 'Não',
+
+  // page pressure widget (connected)
+  // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/pressure/page.connected.js
+  'page--pressure-widget.form.validation.title-text.required': 'Insira um título para o formulário',
+  'page--pressure-widget.form.validation.button-text.required': 'Insira um texto para o botão',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -1,6 +1,7 @@
 export default {
   // page account login
   // filepath: /routes/admin/not-authenticated/account-login/page.js
+  // routepath: /login
   'page--account-login.label.email': 'E-mail',
   'page--account-login.label.password': 'Senha',
   'page--account-login.placeholder.email': 'exemplo@email.com',
@@ -11,6 +12,7 @@ export default {
 
   // page account register
   // filepath: /routes/admin/not-authenticated/account-register/page.js
+  // routepath: /register
   'page--account-register.title': 'Crie sua conta no Bonde.',
   'page--account-register.form.name.label': 'Nome',
   'page--account-register.form.name.placeholder': 'Seu nome',
@@ -31,6 +33,7 @@ export default {
 
   // page account edit
   // filepath: /routes/admin/authenticated/sidebar/account-edit/page.js
+  // routepath: /account/edit
   'page--account-edit.header.title': 'Minha conta',
   'page--account-edit.header.tabs.user': 'Usuário',
   'page--account-edit.form.name.label': 'Nome',
@@ -41,6 +44,7 @@ export default {
 
   // page subscription edit
   // filepath: /routes/public/subscription-edit/page.js
+  // routepath: /subscriptions/:id/edit
   'page--subscription-edit.title': 'Dados da Doação',
   'page--subscription-edit.helper-text': 'Selecione abaixo qual informação da sua doação quer alterar:',
   'page--subscription-edit.button.creditcard': 'Cartão de crédito',
@@ -48,6 +52,7 @@ export default {
 
   // form subscription credit card
   // filepath: /client/subscriptions/forms/credit-card-form.js
+  // routepath: /subscriptions/:id/edit
   'form--subscription-creditcard.helper-text': 'Altere os dados do seu cartão de crédito preenchendo os campos abaixo. Sua doação continuará a mesma mas, a partir do momento em que salvar os dados abaixo, o valor será cobrado neste novo cartão ; )',
 
   'form--subscription-creditcard.previous-data.title': 'Dados do último cartão',
@@ -67,6 +72,7 @@ export default {
 
   // form subscription recurring
   // filepath: /client/subscriptions/forms/recurring-form.js
+  // routepath: /subscriptions/:id/edit
   'form--subscription-recurring.helper-text': 'Preencha os campos abaixo para alterar a data em que a cobrança da sua doação é efetuada. Sua doação continuará a mesma mas, a partir do momento em que salvar os dados abaixo, o valor será cobrado neste novo cartão ; )',
   'form--subscription-recurring.form.process-at.label': 'Nova data de cobrança',
   'form--subscription-recurring.form.process-at.placeholder': 'Ex: DD/MM/AAAA',
@@ -76,6 +82,7 @@ export default {
 
   // notifications
   // filepath: /client/utils/notifications.js
+  // routepath: /subscriptions/:id/edit
   'notification--generic-request-error.title': 'Ops!',
   'notification--generic-request-error.message': 'Parece que teve algum problema técnico nessa última requisição. Pedimos que tente de novo daqui a pouco.',
   'notification--generic-save-success.title': 'Oba!',
@@ -83,12 +90,20 @@ export default {
 
   // page community list
   // filepath: /routes/admin/authenticated/external/community-list/page.js
+  // routepath: /community
   'page--community-list.title': 'Olá {userFirstName},',
   'page--community-list.subtitle': 'Escolha uma das suas comunidades',
   'page--community-list.new': 'Crie uma nova comunidade',
 
   // component community settings menu
   // filepath: /client/community/components/settings-menu.js
+  // routepath:
+  //   - /community/domain
+  //   - /community/domain/add
+  //   - /community/info
+  //   - /community/mailchimp
+  //   - /community/recipient
+  //   - /community/report
   'community.components--settings-menu.title': 'Configurações da comunidade',
   'community.components--settings-menu.tabs.info': 'Informações',
   'community.components--settings-menu.tabs.mailchimp': 'Mailchimp',
@@ -98,16 +113,19 @@ export default {
 
   // component community domain preview
   // filepath: /client/community/components/dns/dns-preview/domain-preview.js
+  // routepath: /community/domain/add
   'community.components--domain-preview.li.domain.header': 'Domínio da comunidade',
 
   // component community subdomain preview
   // filepath: /client/community/components/dns/dns-preview/subdomain-preview.js
+  // routepath: /community/domain
   'community.components--subdomain-preview.li.subdomain.header': 'Subdomínio',
   'community.components--subdomain-preview.li.record-type.header': 'Tipo',
   'community.components--subdomain-preview.li.redirect-to.header': 'Redirecionar para',
 
   // component community subdomain form
   // filepath: /client/community/components/dns/subdomain-form/index.js
+  // routepath: /community/domain
   'community.components--subdomain-form.subdomain.label': 'Subdomínio',
   'community.components--subdomain-form.record-type.label': 'Tipo',
   'community.components--subdomain-form.redirect-to.label': 'Redirecionar para',
@@ -115,6 +133,7 @@ export default {
 
   // page community domain
   // filepath: /routes/admin/authenticated/sidebar/community-settings/domain/page.js
+  // routepath: /community/domain
   'page--community-domain.form.validation.required': 'Preenchimento obrigatório',
 
   'page--community-domain.section--dns-hosted-zone.title': 'Domínios da comunidade',
@@ -131,11 +150,13 @@ export default {
 
   // component dialog
   // filepath: /client/ux/components/dialog/index.js
+  // routepath: /community/domain
   'ux.components--dialog.button.confirm.text': 'Confirmar',
   'ux.components--dialog.button.cancel.text': 'Cancelar',
 
   // page community domain create
   // filepath: /routes/admin/authenticated/sidebar/community-settings/domain-create/page.js
+  // routepath: /community/domain/add
   'page--community-domain-create.title': 'Domínio da comunidade',
 
   'page--community-domain-create.step-add.title': 'Insira o domínio desejado',
@@ -159,6 +180,7 @@ export default {
 
   // page community info
   // filepath: /routes/admin/authenticated/sidebar/community-settings/info/page.js
+  // routepath: /community/info
   'page--community-info.form.name.label': 'Nome',
   'page--community-info.form.name.validation.required': 'Informe o nome da comunidade',
   'page--community-info.form.description.label': 'Descrição',
@@ -170,17 +192,38 @@ export default {
 
   // component settings form
   // filepath: /client/ux/components/settings-form/index.js
+  // routepath:
+  //   - /account/edit
+  //   - /community/info
+  //   - /community/mailchimp
+  //   - /community/recipient
+  //   - /mobilizations/:mobilization_id/analytics
+  //   - /mobilizations/:mobilization_id/basics
+  //   - /mobilizations/:mobilization_id/customDomain
+  //   - /mobilizations/:mobilization_id/sharing
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/email
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
   'ux.components--settings-form.button.text': 'Salvar',
   'ux.components--settings-form.success-message': 'Dados editados com sucesso',
 
   // page community mailchimp
   // filepath: /routes/admin/authenticated/sidebar/community-settings/mailchimp/page.js
+  // routepath: /community/mailchimp
   'page--community-mailchimp.form.api-key.label': 'Mailchimp API Key',
   'page--community-mailchimp.form.list-id.label': 'Mailchimp ID da lista',
   'page--community-mailchimp.form.group-id.label': 'Mailchimp ID do grupo',
 
   // page community new
   // filepath: /routes/admin/authenticated/external/community-new/page.js
+  // routepath: /community/new
   'page--community-new.title': 'Crie uma comunidade',
   'page--community-new.subtitle': 'Comunidades do Bonde são grupos de ação que trabalham juntos por uma causa.',
 
@@ -193,11 +236,13 @@ export default {
 
   // page community new (connected)
   // filepath: /routes/admin/authenticated/external/community-new/page.connected.js
+  // routepath: /community/new
   'page--community-new.form.name.validation.required': 'Informe o nome da comunidade',
   'page--community-new.form.city.validation.required': 'Informe em qual cidade sua comunidade atua',
 
   // page community recipient
   // filepath: /routes/admin/authenticated/sidebar/community-settings/recipient/page.js
+  // routepath: /community/recipient
   'page--community-recipient.form.transfer-interval.label': 'Intervalo',
   'page--community-recipient.form.transfer-interval.value.weekly': 'Semanalmente',
   'page--community-recipient.form.transfer-interval.value.monthly': 'Mensalmente',
@@ -218,6 +263,7 @@ export default {
 
   // page community recipient (connected)
   // filepath: /routes/admin/authenticated/sidebar/community-settings/recipient/page.connected.js
+  // routepath: /community/recipient
   'page--community-recipient.form.validation.required': 'Campo obrigatório',
   'page--community-recipient.form.bank-agency.validation.max-length': 'Deve conter no máximo 5 digitos',
   'page--community-recipient.form.bank-agency-dv.validation.length': 'Deve conter apenas 1 digito',
@@ -230,6 +276,7 @@ export default {
 
   // page community report
   // filepath: /routes/admin/authenticated/sidebar/community-settings/report/page.js
+  // routepath: /community/report
   'page--community-report.section-button.donation.title': 'RELATÓRIO DE DOAÇÕES',
   'page--community-report.section-button.donation.helper-text': 'Clique no botão abaixo para baixar o relatório de doações da comunidade.',
   'page--community-report.section-button.donation.text': 'Baixar',
@@ -244,6 +291,42 @@ export default {
 
   // component sidebar
   // filepath: /client/components/navigation/sidebar/sidebar.js
+  // routepath:
+  //   - /account/edit
+  //   - /community/domain
+  //   - /community/domain/add
+  //   - /community/info
+  //   - /community/mailchimp
+  //   - /community/recipient
+  //   - /community/report
+  //   - /mobilizations
+  //   - /mobilizations/:mobilization_id/analytics
+  //   - /mobilizations/:mobilization_id/basics
+  //   - /mobilizations/:mobilization_id/blocks/create
+  //   - /mobilizations/:mobilization_id/customDomain
+  //   - /mobilizations/:mobilization_id/edit
+  //   - /mobilizations/:mobilization_id/launch
+  //   - /mobilizations/:mobilization_id/launch/end
+  //   - /mobilizations/:mobilization_id/sharing
+  //   - /mobilizations/:mobilization_id/templates/choose
+  //   - /mobilizations/:mobilization_id/templates/choose/custom
+  //   - /mobilizations/:mobilization_id/templates/choose/global
+  //   - /mobilizations/:mobilization_id/templates/create
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/export
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/export
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/fields
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/email
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
+  //   - /mobilizations/new
+  //   - /mobilizations/templates/list
   'components.navigation--sidebar.community-settings.item.mobilizations': 'Minhas Mobilizações',
   'components.navigation--sidebar.community-settings.item.info': 'Informações',
   'components.navigation--sidebar.community-settings.item.mailchimp': 'Mailchimp',
@@ -263,51 +346,118 @@ export default {
 
   // component sidenav
   // filepath: /client/components/navigation/sidenav/sidenav.js
+  // routepath:
+  //   - /account/edit
+  //   - /community/domain
+  //   - /community/domain/add
+  //   - /community/info
+  //   - /community/mailchimp
+  //   - /community/recipient
+  //   - /community/report
+  //   - /mobilizations
+  //   - /mobilizations/:mobilization_id/analytics
+  //   - /mobilizations/:mobilization_id/basics
+  //   - /mobilizations/:mobilization_id/blocks/create
+  //   - /mobilizations/:mobilization_id/customDomain
+  //   - /mobilizations/:mobilization_id/edit
+  //   - /mobilizations/:mobilization_id/launch
+  //   - /mobilizations/:mobilization_id/launch/end
+  //   - /mobilizations/:mobilization_id/sharing
+  //   - /mobilizations/:mobilization_id/templates/choose
+  //   - /mobilizations/:mobilization_id/templates/choose/custom
+  //   - /mobilizations/:mobilization_id/templates/choose/global
+  //   - /mobilizations/:mobilization_id/templates/create
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/export
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/export
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/fields
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/email
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
+  //   - /mobilizations/new
+  //   - /mobilizations/templates/list
   'components.navigation--sidenav.config': 'Configurações',
   'components.navigation--sidenav.change-community': 'Trocar',
 
   // page mobilizations list
   // filepath: /routes/admin/authenticated/sidebar/mobilizations-list/page.js
+  // routepath: /mobilizations
   'page--mobilizations-list.page-header.title': 'Suas Mobilizações',
   'page--mobilizations-list.more-menu-action.open': 'Abrir página',
   'page--mobilizations-list.more-menu-action.create-template': 'Criar template',
 
   // component mobilizations page header
   // filepath: /client/mobilizations/components/page-header.js
+  // routepath:
+  //   - /mobilizations
+  //   - /mobilizations/templates/list
   'mobilizations.components--page-header.button.text': 'Nova mobilização',
   'mobilizations.components--tabs.actives': 'Ativas',
   'mobilizations.components--tabs.templates': 'Templates',
 
   // component mobilizations list item: name
   // filepath: /client/mobilizations/components/list/items/name/index.js
+  // routepath:
+  //   - /mobilizations
+  //   - /mobilizations/templates/list
+  //   - /mobilizations/:mobilization_id/templates/choose/custom
+  //   - /mobilizations/:mobilization_id/templates/choose/global
+  //   - /mobilizations/:mobilization_id/templates/create
   'mobilizations.components--list.items.name.header.text': 'Nome',
 
   // component mobilizations list item: created at
   // filepath: /client/mobilizations/components/list/items/created-at.js
+  // routepath:
+  //   - /mobilizations
+  //   - /mobilizations/templates/list
+  //   - /mobilizations/:mobilization_id/templates/choose/custom
+  //   - /mobilizations/:mobilization_id/templates/choose/global
+  //   - /mobilizations/:mobilization_id/templates/create
   'mobilizations.components--list.items.created-at.header.text': 'Criada em',
 
   // component mobilizations list item: users
   // filepath: /client/mobilizations/components/list/items/users.js
+  // routepath:
+  //   - /mobilizations
+  //   - /mobilizations/templates/list
   'mobilizations.components--list.items.users.header.text': 'Usuários',
 
   // component mobilizations list item: fund raising
   // filepath: /client/mobilizations/components/list/items/fund-raising.js
+  // routepath:
+  //   - /mobilizations
+  //   - /mobilizations/templates/list
   'mobilizations.components--list.items.fund-raising.header.text': 'Arrecadações',
   'mobilizations.components--list.items.fund-raising.currency': 'R$',
 
   // component mobilizations page tab layout
   // filepath: /client/mobilizations/components/page-tab-layout.js
+  // routepath:
+  //   - /mobilizations/new
+  //   - /mobilizations/:mobilization_id/templates/choose
+  //   - /mobilizations/:mobilization_id/templates/choose/custom
+  //   - /mobilizations/:mobilization_id/templates/choose/global
   'mobilizations.components--page-tab-layout.title': 'Nova mobilização',
   'mobilizations.components--tabs.goal': 'Objetivo',
   'mobilizations.components--tabs.templates': 'Templates',
 
   // page mobilizations new
   // filepath: /routes/admin/authenticated/sidebar/mobilizations-new/page.js
+  // routepath: /mobilizations/new
   'page--mobilizations-new.title': 'Qual o objetivo da sua mobilização?',
   'page--mobilizations-new.footer': 'Fique tranquil@ vc poderá editar depois se achar necessário.',
 
   // component mobilizations mobilization basics form
   // filepath: /client/mobilizations/components/mobilization-basics-form.js
+  // routepath:
+  //   - /mobilizations/new
+  //   - /mobilizations/:mobilization_id/basics
   'mobilizations.components--basics-form.name.label': 'Nome',
   'mobilizations.components--basics-form.name.placeholder': 'Ex: Pela criação de uma delegacia de desaparecidos',
   'mobilizations.components--basics-form.name.validation.required': 'Insira o nome da mobilização',
@@ -319,11 +469,40 @@ export default {
 
   // component control buttons
   // filepath: /client/components/forms/control-buttons.js
+  // routepath:
+  //   - /account/edit
+  //   - /community/domain
+  //   - /community/domain/add
+  //   - /community/info
+  //   - /community/mailchimp
+  //   - /community/new
+  //   - /community/recipient
+  //   - /login
+  //   - /mobilizations/:mobilization_id/analytics
+  //   - /mobilizations/:mobilization_id/basics
+  //   - /mobilizations/:mobilization_id/customDomain
+  //   - /mobilizations/:mobilization_id/launch
+  //   - /mobilizations/:mobilization_id/sharing
+  //   - /mobilizations/:mobilization_id/templates/create
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/email
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
+  //   - /mobilizations/new
+  //   - /register
+  //   - /subscriptions/:id/edit
   'components--control-buttons.input.value.default': 'Continuar',
   'components--control-buttons.input.value.saving': 'Salvando...',
 
   // page mobilizations templates choose
   // filepath: /routes/admin/authenticated/sidebar/templates-choose/page.js
+  // routepath: /mobilizations/:mobilization_id/templates/choose
   'page--mobilizations.templates-choose.title': 'Como você deseja começar?',
   'page--mobilizations.templates-choose.browsable-list-item.blank': 'Criar mobilização do zero',
   'page--mobilizations.templates-choose.browsable-list-item.templates-custom': 'Meus templates',
@@ -331,6 +510,9 @@ export default {
 
   // component mobilizations templates selectable list
   // filepath: /client/mobilizations/templates/components/template-selectable-list.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/templates/choose/custom
+  //   - /mobilizations/:mobilization_id/templates/choose/global
   'templates.components--selectable-list.filterable-search-bar.placeholder': 'Busque um template',
   'templates.components--selectable-list.empty-list-text': 'Não existe nenhum template com esse nome',
   'templates.components--selectable-list.button.back': 'Voltar',
@@ -338,14 +520,21 @@ export default {
 
   // page mobilizations templates choose custom
   // filepath: /routes/admin/authenticated/sidebar/templates-choose-custom/page.js
+  // routepath: /mobilizations/:mobilization_id/templates/choose/custom
   'page--mobilizations.templates-choose-custom.title': 'Meus Templates',
 
   // page mobilizations templates choose global
   // filepath: /routes/admin/authenticated/sidebar/templates-choose-global/page.js
+  // routepath: /mobilizations/:mobilization_id/templates/choose/global
   'page--mobilizations.templates-choose-global.title': 'Templates Globais',
 
   // component mobilizations settings menu
   // filepath: /client/mobilizations/components/settings-menu.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/analytics
+  //   - /mobilizations/:mobilization_id/basics
+  //   - /mobilizations/:mobilization_id/customDomain
+  //   - /mobilizations/:mobilization_id/sharing
   'mobilizations.components--settings-menu.title': 'Configure sua mobilização',
   'mobilizations.components--settings-menu.tabs.info': 'Informações básicas',
   'mobilizations.components--settings-menu.tabs.sharing': 'Compartilhamento',
@@ -353,6 +542,7 @@ export default {
 
   // page mobilizations settings analytics
   // filepath: /routes/admin/authenticated/sidebar/mobilizations-settings-analytics/page.js
+  // routepath: /mobilizations/:mobilization_id/analytics
   'page--mobilizations-analytics.first-paragraph': 'Para acompanhar os resultados da sua mobilização, você precisa configurar uma conta no Google Analytics.',
   'page--mobilizations-analytics.second-paragraph': 'Siga os passos abaixo:',
   'page--mobilizations-analytics.ol.create-analytics-account': ' Crie uma conta no Google Analytics {link}',
@@ -364,10 +554,12 @@ export default {
 
   // page mobilizations settings analytics (connected)
   // filepath: /routes/admin/authenticated/sidebar/mobilizations-settings-analytics/page.connected.js
+  // routepath: /mobilizations/:mobilization_id/analytics
   'page--mobilizations-analytics.ol.form.ga-code.validation.invalid.ga-code.format': 'Informe uma ID válida',
 
   // page block create
   // filepath: /routes/admin/authenticated/sidebar/blocks-create/page.js
+  // routepath: /mobilizations/:mobilization_id/blocks/create
   'page--block-create.title': 'Adicione um bloco de conteúdo',
   'page--block-create.tabs.blank-blocks': 'Blocos em branco',
   'page--block-create.helper-text': 'Os blocos serão adicionados ao fim da sua página, mas você pode trocá-los de ordem a qualquer momento',
@@ -378,10 +570,14 @@ export default {
 
   // page mobilizations domain
   // filepath: /routes/admin/authenticated/sidebar/mobilizations-settings-domain/page.js
+  // routepath: /mobilizations/:mobilization_id/customDomain
   'page--mobilizations-domain.form-domain.success-message': 'Dados de domínio salvos com sucesso',
 
   // component mobilizations form domain
   // filepath: /client/mobilizations/components/form-domain.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/customDomain
+  //   - /mobilizations/:mobilization_id/launch
   'mobilizations.components--form-domain.basic.header-toggle.use-existing-domain': 'Quero usar o domínio principal da minha comunidade',
   'mobilizations.components--form-domain.basic.header-toggle.create-domain': 'Quero cadastrar um domínio principal na minha comunidade',
   'mobilizations.components--form-domain.basic.helper-text': 'Preencha abaixo o subdomínio e escolha o domínio que deseja configurar como endereço da sua mobilização',
@@ -405,10 +601,14 @@ export default {
 
   // component mobrender mobilization
   // filepath: /client/mobrender/components/mobilization.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/edit
+  //   - (public) /
   'mobrender.components--mobilization.footer.slogan': 'Feito pra causar. Feito com',
 
   // component mobrender block config menu
   // filepath: /client/mobrender/components/block-config-menu.js
+  // routepath: /mobilizations/:mobilization_id/edit
   'mobrender.components--block-config-menu.item.change-background': 'Alterar fundo',
   'mobrender.components--block-config-menu.item.toggle-visibility.show': 'Mostrar',
   'mobrender.components--block-config-menu.item.toggle-visibility.hide': 'Esconder',
@@ -419,15 +619,22 @@ export default {
 
   // component mobrender block change background
   // filepath: /client/mobrender/components/block-change-background.js
+  // routepath: /mobilizations/:mobilization_id/edit
   'mobrender.components--block-change-background.button.save': 'Salvar',
   'mobrender.components--block-change-background.button.cancel': 'Cancelar',
 
   // component navigation navbar edition wrapper
   // filepath: /client/components/navigation/navbar/navbar-edition-wrapper.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/edit
+  //   - (public) /
   'components.navigation--navbar-edition-wrapper.block': 'Bloco',
 
   // component mobilizations form share
   // filepath: /client/mobilizations/components/form-share.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/launch
+  //   - /mobilizations/:mobilization_id/sharing
   'mobilizations.components--form-share.facebook.title': 'Share de Facebook',
   'mobilizations.components--form-share.facebook.helper-text': 'Configure o post que será publicado no Facebook sempre que alguém compartilhar a ação. É importante que esses textos sejam cativantes e curtos para não aparecerem cortados. :)',
   'mobilizations.components--form-share.facebook.form.share-image.label': 'Imagem',
@@ -443,6 +650,7 @@ export default {
 
   // page mobilizations launch
   // filepath: /routes/admin/authenticated/sidebar/mobilizations-launch/page.js
+  // routepath: /mobilizations/:mobilization_id/launch
   'page--mobilizations-launch.title': 'Lançando sua mobilização',
   'page--mobilizations-launch.steps.form-domain.title': 'Configure o endereço da mobilização',
   'page--mobilizations-launch.steps.form-share.title': 'Configure as informações de compartilhamento',
@@ -456,6 +664,7 @@ export default {
 
   // page mobilizations launch end
   // filepath: /routes/admin/authenticated/sidebar/mobilizations-launch-end/page.js
+  // routepath: /mobilizations/:mobilization_id/launch/end
   'page--mobilizations-launch-end.heading.all-done': 'Tudo pronto?',
   'page--mobilizations-launch-end.heading.just-launch': 'Agora é só lançar e contar pra todo mundo!',
   'page--mobilizations-launch-end.title': 'Chegou a hora',
@@ -463,16 +672,17 @@ export default {
 
   // page templates list
   // filepath: /routes/admin/authenticated/sidebar/templates-list/page.js
+  // routepath: /mobilizations/templates/list
   'page--templates-list.header.title': 'Seus templates',
   'page--templates-list.empty-list.no-template': 'Nenhum template criado.',
   'page--templates-list.empty-list.create-one': 'Crie a partir de uma mobilização.',
   'page--templates-list.empty-list.mobilization-list': 'Lista de mobilizações',
   'page--templates-list.more-menu-action.remove.text': 'Remover',
   'page--templates-list.more-menu-action.remove.confirm': 'Tem certeza que deseja remover este template? Ao confirmar, não é possível desfazer esta ação.',
-  'page--templates-list.more-menu-action.remove.confirm': 'Tem certeza que deseja remover este template? Ao confirmar, não é possível desfazer esta ação.',
 
   // page templates create
   // filepath: /routes/admin/authenticated/sidebar/templates-create/page.js
+  // routepath: /mobilizations/:mobilization_id/templates/create
   'page--templates-create.header.title': 'Crie um template a partir da mobilização',
   'page--templates-create.form.name.label': 'Nome do seu template',
   'page--templates-create.form.name.placeholder': 'Pela criação de uma delegacia de desaparecidos',
@@ -481,6 +691,10 @@ export default {
 
   // component donation widget settings menu
   // filepath: /client/mobilizations/widgets/__plugins__/donation/components/settings-menu.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
   'donation.components--settings-menu.title': 'Configure o bloco de doação',
   'donation.components--settings-menu.tabs.adjusts': 'Ajustes',
   'donation.components--settings-menu.tabs.autofire': 'Mensagem agradecimento',
@@ -488,6 +702,7 @@ export default {
 
   // page donation widget
   // filepath: /routes/admin/authenticated/sidebar/widgets-donation-settings/donation/page.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/donation
   'page--donation-widget.header.title': 'Crie um template a partir da mobilização',
   'page--donation-widget.form.submit-button': 'Salvar',
   'page--donation-widget.form.success-message': 'Formulário de doação configurado com sucesso!',
@@ -528,11 +743,16 @@ export default {
 
   // page donation widget (connected)
   // filepath: /routes/admin/authenticated/sidebar/widgets-donation-settings/donation/page.connected.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/donation
   'page--donation-widget.form.validation.button-text.required': 'Insira o texto do botão',
   'page--donation-widget.form.validation.button-text.max-length': 'O limite de caracteres foi atingido.',
 
   // component widget autofire
   // filepath: /client/mobilizations/widgets/components/form-autofire.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/autofire
   'widgets.components--form-autofire.form.submit-button': 'Salvar',
   'widgets.components--form-autofire.form.success-message': 'Mensagem de agradecimento configurada com sucesso!',
   'widgets.components--form-autofire.form.sender-name.label': 'Nome do remetente',
@@ -547,6 +767,10 @@ export default {
 
   // component widget form finish message
   // filepath: /client/mobilizations/widgets/components/form-finish-message/index.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
   'widgets.components--form-finish-message.success-message': 'Formulário salvo com sucesso!',
   'widgets.components--form-finish-message.type.label': 'Tipo de mensagem',
   'widgets.components--form-finish-message.type.radio.share': 'Compartilhar',
@@ -559,30 +783,55 @@ export default {
 
   // component share tell-a-friend
   // filepath: /client/components/share/tell-a-friend.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
+  //   - (public) /
   'share.components--tell-a-friend.text': 'Agora, compartilhe com seus amigos!',
 
   // component share facebook-share-button
   // filepath: /client/components/share/facebook-share-button.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
+  //   - (public) /
   'share.components--facebook-share-button.text': 'Compartilhar no Facebook',
 
   // component share twitter-share-button
   // filepath: /client/components/share/twitter-share-button.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
+  //   - (public) /
   'share.components--twitter-share-button.text': 'Compartilhar no Twitter',
 
   // component share whatsapp-share-button
   // filepath: /client/components/share/whatsapp-share-button.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
+  //   - (public) /
   'share.components--whatsapp-share-button.text': 'Compartilhar no WhatsApp',
 
   // page donation widget finish
   // filepath: /routes/admin/authenticated/sidebar/widgets-donation-settings/finish/page.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
   'page--donation-widget-finish.form.success-message': 'Formulário de pós-doação salvo com sucesso!',
 
   // component donation widget tell-a-friend
   // filepath: /client/mobilizations/widgets/__plugins__/donation/components/donation-tell-a-friend.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+  //   - (public) /
   'donation.components--tell-a-friend.message': 'Oba, doação registrada! Sua doação é via boleto? Verifique seu email.',
 
   // config mobrender widgets
   // filepath: /client/mobrender/widgets/config.js
+  // routepath: /mobilizations/:mobilization_id/edit
   'widgets.config--content.label': 'Texto',
   'widgets.config--content.default': 'Clique aqui para editar...',
   'widgets.config--form.label': 'Formulário',
@@ -594,6 +843,9 @@ export default {
 
   // component donation widget
   // filepath: /client/mobilizations/widgets/__plugins__/donation/components/__donation__/index.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/edit
+  //   - (public) /
   'widgets.components--donation.default.button-text': 'Doar agora',
   'widgets.components--donation.default.title-text': 'Clique para configurar seu bloco de doação',
   'widgets.components--donation.period-label-options.month': 'mês',
@@ -604,6 +856,12 @@ export default {
 
   // component form widget settings menu
   // filepath: /client/mobilizations/widgets/__plugins__/form/components/settings-menu.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/export
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/fields
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
   'form-widget.components--settings-menu.title': 'Configure o formulário da sua ação',
   'form-widget.components--settings-menu.items.fields': 'Campos do formulário',
   'form-widget.components--settings-menu.items.adjusts': 'Ajustes',
@@ -613,6 +871,7 @@ export default {
 
   // page form widget
   // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/form/page.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/form
   'page--form-widget.form.success-message': 'Formulário configurado com sucesso!',
   'page--form-widget.form.widget-title.label': 'Título do formulário',
   'page--form-widget.form.widget-title.placeholder': 'Ex: Preencha o formulário abaixo para assinar a petição.',
@@ -623,6 +882,7 @@ export default {
 
   // component data export
   // filepath: /client/mobilizations/widgets/components/data-export.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/form/export
   'widgets.components--data-export.formated-export-at': '{date} às {time}',
   'widgets.components--data-export.loading.message': 'Aguarde enquanto estamos processando...',
   'widgets.components--data-export.exported.message': 'Última exportação: {formatedExportAt}.',
@@ -632,28 +892,35 @@ export default {
 
   // action async widget data export
   // filepath: /client/mobrender/redux/action-creators/async-widget-data-export.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/form/export
   'action--async-widget-data-export.no-data': 'Nao foi encontrado nenhum dado para ser exportado',
 
   // page form widget fields
   // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/fields/page.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/form/fields
   'page--form-widget-fields.add-button': 'Adicionar um campo',
   'page--form-widget-fields.helper-text.still-empty': 'Seu formulário ainda não possui nenhum campo. Clique abaixo para começar a adicionar campos.',
   'page--form-widget-fields.helper-text.manage-fields': 'Adicione, remova, edite e ordene os campos do formulário de acordo com as necessidades da sua ação.',
 
   // component form widget
   // filepath: /client/mobilizations/widgets/__plugins__/form/components/__form__.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/edit
+  //   - (public) /
   'form-widget.components--form.default.title-text': 'Clique para configurar seu formulário...',
   'form-widget.components--form.default.button-text': 'Enviar',
   'form-widget.components--form.default.counter-suffix': 'assinaturas',
 
   // component form widget input
   // filepath: /client/mobilizations/widgets/__plugins__/form/components/input.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/form/fields
   'form-widget.components--input.click-to-edit': 'Clique para editar',
   'form-widget.components--input.field-dropdown.options.default': 'Selecione...',
   'form-widget.components--input.field-greetings.title': 'Mensagem de sucesso alterada para:',
 
   // component form widget input form
   // filepath: /client/mobilizations/widgets/__plugins__/form/components/input-form.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/form/fields
   'form-widget.components--input-form.handle-remove.confirm': 'Você tem certeza que quer remover este campo?',
   'form-widget.components--input-form.handle-overlay-click.confirm': 'Ao sair sem salvar você perderá suas modificações. Deseja sair sem salvar?',
   'form-widget.components--input-form.field-title.label': 'Título do campo',
@@ -678,19 +945,29 @@ export default {
 
   // component mobrender widget overlay
   // filepath: /client/mobrender/components/widget-overlay.js
+  // routepath: /mobilizations/:mobilization_id/edit
   'mobrender.components--widget-overlay.button.edit.title': 'Editar',
   'mobrender.components--widget-overlay.button.remove.title': 'Remover',
 
   // page form widget finish
   // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/finish/page.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
   'page--form-widget-finish.success-message': 'Formulário de pós-inscrição salvo com sucesso!',
 
   // component form widget tell a friend
   // filepath: /client/mobilizations/widgets/__plugins__/form/components/form-tell-a-friend.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+  //   - (public) /
   'form-widget.components--tell-a-friend.message': 'Formulário submetido com sucesso!',
 
   // component pressure widget settings menu
   // filepath: /client/mobilizations/widgets/__plugins__/pressure/components/settings-menu.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/autofire
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/email
+  //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
   'pressure-widget.components--settings-menu.title': 'Configure seu formulário de pressão',
   'pressure-widget.components--settings-menu.items.form': 'Formulário',
   'pressure-widget.components--settings-menu.items.pressure-email': 'E-mail para alvo',
@@ -698,7 +975,8 @@ export default {
   'pressure-widget.components--settings-menu.items.post-action': 'Pós-pressão',
 
   // page pressure widget
-  // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/finish/page.js
+  // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/pressure/page.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/pressure
   'page--pressure-widget.success-message': 'Formulário de pressão configurado com sucesso!',
   'page--pressure-widget.form.title-text.label': 'Título do formulário',
   'page--pressure-widget.form.title-text.placeholder': 'Envie um e-mail para quem pode tomar essa decisão',
@@ -716,16 +994,19 @@ export default {
 
   // page pressure widget (connected)
   // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/pressure/page.connected.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/pressure
   'page--pressure-widget.form.validation.title-text.required': 'Insira um título para o formulário',
   'page--pressure-widget.form.validation.button-text.required': 'Insira um texto para o botão',
 
   // component widgets input tag
   // filepath: /client/mobilizations/widgets/components/input-tag.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/pressure/email
   'widgets.components--input-tag.helper-text.target-format': '1. Informe nome e email. Ex.: Nome <email@provedor.com>',
   'widgets.components--input-tag.helper-text.enter-to-add': '2. Pressione <Enter> para adicionar mais alvos.',
 
   // page pressure widget email
   // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/pressure/email
   'page--pressure-widget-email.success-message': 'Email para alvo configurado com sucesso!',
   'page--pressure-widget-email.form.input-tag.label': 'Alvos',
   'page--pressure-widget-email.form.input-tag.validation.invalid-target-format': 'Alvo fora do formato padrão. Ex.: Nome do alvo <alvo@provedor.com>',
@@ -734,14 +1015,17 @@ export default {
 
   // page pressure widget email (connected)
   // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.connected.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/pressure/email
   'page--pressure-widget-email.form.validation.required': 'Preenchimento obrigatório',
 
   // page pressure widget finish
   // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/finish/page.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
   'page--pressure-widget-finish.success-message': 'Formulário de pós-pressão salvo com sucesso!',
 
   // component pressure widget tell a friend
   // filepath: /client/mobilizations/widgets/__plugins__/pressure/components/pressure-tell-a-friend.js
+  // routepath: /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
   'pressure-widget--tell-a-friend.message': 'Pressão enviada',
 
   //

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -680,4 +680,12 @@ export default {
   // filepath: /client/mobrender/components/widget-overlay.js
   'mobrender.components--widget-overlay.button.edit.title': 'Editar',
   'mobrender.components--widget-overlay.button.remove.title': 'Remover',
+
+  // page form widget finish
+  // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/finish/page.js
+  'page--form-widget-finish.success-message': 'Formulário de pós-inscrição salvo com sucesso!',
+
+  // component form widget tell a friend
+  // filepath: /client/mobilizations/widgets/__plugins__/form/components/form-tell-a-friend.js
+  'form-widget.components--tell-a-friend.message': 'Formulário submetido com sucesso!',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -315,4 +315,11 @@ export default {
   // filepath: /client/components/forms/control-buttons.js
   'components--control-buttons.input.value.default': 'Continuar',
   'components--control-buttons.input.value.saving': 'Salvando...',
+
+  // page mobilizations templates choose
+  // filepath: /routes/admin/authenticated/sidebar/templates-choose/page.js
+  'page--mobilizations.templates-choose.title': 'Como você deseja começar?',
+  'page--mobilizations.templates-choose.browsable-list-item.blank': 'Criar mobilização do zero',
+  'page--mobilizations.templates-choose.browsable-list-item.templates-custom': 'Meus templates',
+  'page--mobilizations.templates-choose.browsable-list-item.templates-global': 'Templates globais',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -65,4 +65,9 @@ export default {
   'notification--generic-request-error.message': 'Parece que teve algum problema técnico nessa última requisição. Pedimos que tente de novo daqui a pouco.',
   'notification--generic-save-success.title': 'Oba!',
   'notification--generic-save-success.message': 'A requisição foi feita com sucesso e, os seus dados estão salvos em segurança.',
+
+  // page community list
+  'page--community-list.title': 'Olá {userFirstName},',
+  'page--community-list.subtitle': 'Escolha uma das suas comunidades',
+  'page--community-list.new': 'Crie uma nova comunidade',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -78,4 +78,28 @@ export default {
   'community.components--settings-menu.tabs.recipient': 'Recebedor',
   'community.components--settings-menu.tabs.report': 'Relatório',
   'community.components--settings-menu.tabs.domains': 'Domínios',
+
+  // component community domain preview
+  'community.components--domain-preview.li.domain.header': 'Domínio da comunidade',
+
+  // component community subdomain preview
+  'community.components--subdomain-preview.li.subdomain.header': 'Subdomínio',
+  'community.components--subdomain-preview.li.record-type.header': 'Tipo',
+  'community.components--subdomain-preview.li.redirect-to.header': 'Redirecionar para',
+
+  // page community domain
+  'page--community-domain.section--dns-hosted-zone.title': 'Domínios da comunidade',
+  'page--community-domain.section--dns-hosted-zone.add': 'Adicionar novo domínio',
+  'page--community-domain.section--dns-hosted-zone.menu.subdomains': 'Subdomínios',
+  'page--community-domain.section--dns-hosted-zone.menu.remove': 'Remover domínio',
+  'page--community-domain.section--dns-hosted-zone.menu.remove.dialog.text': 'Tem certeza que deseja remover o domínio {domainName}?',
+  'page--community-domain.section--dns-hosted-zone.menu.check-dns': 'Verificar DNS',
+  'page--community-domain.section--dns-records.title': 'Subdomínios externos',
+  'page--community-domain.section--dns-records.add': 'Adicionar novo subdomínio externo',
+  'page--community-domain.section--dns-records.menu.remove': 'Remover subdomínio',
+  'page--community-domain.section--dns-records.menu.remove.dialog.text': 'Tem certeza que deseja remover o subdomínio {subdomainName}?',
+
+  // component dialog
+  'ux.components--dialog.button.confirm.text': 'Confirmar',
+  'ux.components--dialog.button.cancel.text': 'Cancelar',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -6,7 +6,7 @@ export default {
   'page--account-login.loading': 'Carregando...',
   'page--account-login.signin': 'Entrar',
   'page--account-login.ask-register': 'Ainda não é cadastrado?',
-  'page--account-login.cta-signup': 'Clique para criar uma conta.'
+  'page--account-login.cta-signup': 'Clique para criar uma conta.',
 
   // page account register
   'page--account-register.title': 'Crie sua conta no Bonde.',
@@ -155,4 +155,9 @@ export default {
   // component settings form
   'ux.components--settings-form.button.text': 'Salvar',
   'ux.components--settings-form.success-message': 'Dados editados com sucesso',
+
+  // page community mailchimp
+  'page--community-mailchimp.form.api-key.label': 'Mailchimp API Key',
+  'page--community-mailchimp.form.list-id.label': 'Mailchimp ID da lista',
+  'page--community-mailchimp.form.group-id.label': 'Mailchimp ID do grupo',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -70,4 +70,12 @@ export default {
   'page--community-list.title': 'Olá {userFirstName},',
   'page--community-list.subtitle': 'Escolha uma das suas comunidades',
   'page--community-list.new': 'Crie uma nova comunidade',
+
+  // component community settings menu
+  'community.components--settings-menu.title': 'Configurações da comunidade',
+  'community.components--settings-menu.tabs.info': 'Informações',
+  'community.components--settings-menu.tabs.mailchimp': 'Mailchimp',
+  'community.components--settings-menu.tabs.recipient': 'Recebedor',
+  'community.components--settings-menu.tabs.report': 'Relatório',
+  'community.components--settings-menu.tabs.domains': 'Domínios',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -333,4 +333,8 @@ export default {
   // page mobilizations templates choose custom
   // filepath: /routes/admin/authenticated/sidebar/templates-choose-custom/page.js
   'page--mobilizations.templates-choose-custom.title': 'Meus Templates',
+
+  // page mobilizations templates choose global
+  // filepath: /routes/admin/authenticated/sidebar/templates-choose-global/page.js
+  'page--mobilizations.templates-choose-global.title': 'Templates Globais',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -530,4 +530,18 @@ export default {
   // filepath: /routes/admin/authenticated/sidebar/widgets-donation-settings/donation/page.connected.js
   'page--donation-widget.form.validation.button-text.required': 'Insira o texto do botão',
   'page--donation-widget.form.validation.button-text.max-length': 'O limite de caracteres foi atingido.',
+
+  // component widget autofire
+  // filepath: /client/mobilizations/widgets/components/form-autofire.js
+  'widgets.components--form-autofire.form.submit-button': 'Salvar',
+  'widgets.components--form-autofire.form.success-message': 'Mensagem de agradecimento configurada com sucesso!',
+  'widgets.components--form-autofire.form.sender-name.label': 'Nome do remetente',
+  'widgets.components--form-autofire.form.sender-name.placeholder': 'Defina o nome que irá aparecer na mensagem enviada.',
+  'widgets.components--form-autofire.form.sender-email.label': 'E-mail remetente',
+  'widgets.components--form-autofire.form.sender-email.placeholder': 'Defina o e-mail que irá aparecer na mensagem enviada.',
+  'widgets.components--form-autofire.form.sender-email.validation.invalid-email-format': 'Informe um e-mail inválido',
+  'widgets.components--form-autofire.form.email-subject.label': 'Assunto do e-mail',
+  'widgets.components--form-autofire.form.email-subject.placeholder': 'Defina o assunto que irá aparecer na mensagem enviada.',
+  'widgets.components--form-autofire.form.email-text.label': 'Email de agradecimento',
+  'widgets.components--form-autofire.form.email-text.placeholder': 'Ex: Obrigado por apostar na força da ação coletiva em rede. Sua participação é muito importante e, agora, precisamos da sua ajuda para que mais gente colabore com esta mobilização. Compartilhe nas suas redes clicando em um dos links abaixo. Um abraço.',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -735,4 +735,12 @@ export default {
   // page pressure widget email (connected)
   // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.connected.js
   'page--pressure-widget-email.form.validation.required': 'Preenchimento obrigatório',
+
+  // page pressure widget finish
+  // filepath: /routes/admin/authenticated/sidebar/widgets-pressure-settings/finish/page.js
+  'page--pressure-widget-finish.success-message': 'Formulário de pós-pressão salvo com sucesso!',
+
+  // component pressure widget tell a friend
+  // filepath: /client/mobilizations/widgets/__plugins__/pressure/components/pressure-tell-a-friend.js
+  'pressure-widget--tell-a-friend.message': 'Pressão enviada',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -601,4 +601,14 @@ export default {
   'widgets.components--donation.period-label-options.year': 'ano',
   'widgets.components--donation.users-choice.recurring': 'Apoiar todo {periodLabelCurrent}',
   'widgets.components--donation.users-choice.unique': 'Doação única',
+
+  // page form widget
+  // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/form/page.js
+  'widgets.components--form.form.success-message': 'Formulário configurado com sucesso!',
+  'widgets.components--form.form.widget-title.label': 'Título do formulário',
+  'widgets.components--form.form.widget-title.placeholder': 'Ex: Preencha o formulário abaixo para assinar a petição.',
+  'widgets.components--form.form.button-text.label': 'Botão',
+  'widgets.components--form.form.button-text.placeholder': 'Defina o texto do botão de confirmação do formulário.',
+  'widgets.components--form.form.counter-text.label': 'Contador',
+  'widgets.components--form.form.counter-text.placeholder': 'Defina o texto que ficará ao lado do número de pessoas que agiram.',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -611,4 +611,17 @@ export default {
   'widgets.components--form.form.button-text.placeholder': 'Defina o texto do botão de confirmação do formulário.',
   'widgets.components--form.form.counter-text.label': 'Contador',
   'widgets.components--form.form.counter-text.placeholder': 'Defina o texto que ficará ao lado do número de pessoas que agiram.',
+
+  // component data export
+  // filepath: /client/mobilizations/widgets/components/data-export.js
+  'widgets.components--data-export.formated-export-at': '{date} às {time}',
+  'widgets.components--data-export.loading.message': 'Aguarde enquanto estamos processando...',
+  'widgets.components--data-export.exported.message': 'Última exportação: {formatedExportAt}.',
+  'widgets.components--data-export.export.label': 'Exportar',
+  'widgets.components--data-export.export.helper-text': 'Clique no botão abaixo para baixar o relatório completo do formulário em formato excel.',
+  'widgets.components--data-export.export.button': 'Clique para baixar a planilha completa.',
+
+  // action async widget data export
+  // filepath: /client/mobrender/redux/action-creators/async-widget-data-export.js
+  'action--async-widget-data-export.no-data': 'Nao foi encontrado nenhum dado para ser exportado',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -425,4 +425,19 @@ export default {
   // component navigation navbar edition wrapper
   // filepath: /client/components/navigation/navbar/navbar-edition-wrapper.js
   'components.navigation--navbar-edition-wrapper.block': 'Bloco',
+
+  // component mobilizations form share
+  // filepath: /client/mobilizations/components/form-share.js
+  'mobilizations.components--form-share.facebook.title': 'Share de Facebook',
+  'mobilizations.components--form-share.facebook.helper-text': 'Configure o post que será publicado no Facebook sempre que alguém compartilhar a ação. É importante que esses textos sejam cativantes e curtos para não aparecerem cortados. :)',
+  'mobilizations.components--form-share.facebook.form.share-image.label': 'Imagem',
+  'mobilizations.components--form-share.facebook.form.share-title.label': 'Título do post',
+  'mobilizations.components--form-share.facebook.form.share-title.placeholder': 'Um título direto que passe a ideia da sua mobilização',
+  'mobilizations.components--form-share.facebook.form.share-description.label': 'Subtítulo do post',
+  'mobilizations.components--form-share.facebook.form.share-description.placeholder': 'Complete a informação do título e chame o leitor para a mobilização',
+
+  'mobilizations.components--form-share.twitter.title': 'Share de Twitter',
+  'mobilizations.components--form-share.twitter.helper-text': 'Configure a mensagem que será publicada no Twitter sempre que alguém compartilhar sua mobilização.',
+  'mobilizations.components--form-share.twitter.form.share-text.label': 'Texto do Tweet',
+  'mobilizations.components--form-share.twitter.form.share-text.placeholder': 'Insira uma frase e chame o leitor para a mobilização',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -602,6 +602,15 @@ export default {
   'widgets.components--donation.users-choice.recurring': 'Apoiar todo {periodLabelCurrent}',
   'widgets.components--donation.users-choice.unique': 'Doação única',
 
+  // component form widget settings menu
+  // filepath: /client/mobilizations/widgets/__plugins__/form/components/settings-menu.js
+  'form-widget.components--settings-menu.title': 'Configure o formulário da sua ação',
+  'form-widget.components--settings-menu.items.fields': 'Campos do formulário',
+  'form-widget.components--settings-menu.items.adjusts': 'Ajustes',
+  'form-widget.components--settings-menu.items.autofire': 'Mensagem agradecimento',
+  'form-widget.components--settings-menu.items.report': 'Relatório',
+  'form-widget.components--settings-menu.items.post-action': 'Pós-inscrição',
+
   // page form widget
   // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/form/page.js
   'widgets.components--form.form.success-message': 'Formulário configurado com sucesso!',

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -227,4 +227,18 @@ export default {
   'page--community-recipient.form.bank-document-number.validation.cpf-length': 'CPF deve conter 11 digitos',
   'page--community-recipient.form.bank-document-number.validation.invalid-cpf-format': 'CPF inválido',
   'page--community-recipient.form.bank-document-number.validation.invalid-cnpj-format': 'CNPJ inválido',
+
+  // page community report
+  // filepath: /routes/admin/authenticated/sidebar/community-settings/report/page.js
+  'page--community-report.section-button.donation.title': 'RELATÓRIO DE DOAÇÕES',
+  'page--community-report.section-button.donation.helper-text': 'Clique no botão abaixo para baixar o relatório de doações da comunidade.',
+  'page--community-report.section-button.donation.text': 'Baixar',
+
+  'page--community-report.section-button.actions.title': 'RELATÓRIO DE AÇÕES',
+  'page--community-report.section-button.actions.helper-text': 'Clique no botão abaixo para baixar o relatório de ações feitas na comunidade.',
+  'page--community-report.section-button.actions.text': 'Baixar',
+
+  'page--community-report.section-button.activists.title': 'RELATÓRIO DE ATIVISTAS',
+  'page--community-report.section-button.activists.helper-text': 'Clique no botão abaixo para baixar o relatório dos ativistas da comunidade.',
+  'page--community-report.section-button.activists.text': 'Baixar',
 }

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -20,4 +20,13 @@ export default {
   'page--account-register.form.password-confirm.label': 'Confirme sua senha',
   'page--account-register.form.submit-button.default': 'Criar conta',
   'page--account-register.form.submit-button.saving': 'Salvando...',
+
+  // page account edit
+  'page--account-edit.header.title': 'Minha conta',
+  'page--account-edit.header.tabs.user': 'Usuário',
+  'page--account-edit.form.name.label': 'Nome',
+  'page--account-edit.form.lastname.label': 'Sobrenome',
+  'page--account-edit.form.email.label': 'E-mail',
+  'page--account-edit.form.submit-button.default': 'Salvar',
+  'page--account-edit.form.submit-button.success-message': 'Dados editados com sucesso.',
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:prod": "node ./build/server.js",
     "heroku-postbuild": "./node_modules/.bin/webpack --config ./tools/webpack.client.js && ./node_modules/.bin/webpack -p --config ./tools/webpack.server.js",
     "clean": "rm -rf build",
-    "routes": "grep -rhe path: ./routes/$inner | sed -e \"s/path: '\\([a-zA-Z\\/:_]*\\)',/\\1/g\" | sort | uniq",
+    "routes": "grep -rhe @path ./routes/ | sort",
     "release": "./node_modules/.bin/standard-version"
   },
   "repository": {

--- a/routes/admin/authenticated/external/community-list/index.js
+++ b/routes/admin/authenticated/external/community-list/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /community
+//
 export default store => ({
   path: 'community',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/external/community-new/index.js
+++ b/routes/admin/authenticated/external/community-new/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /community/new
+//
 export default store => ({
   path: 'community/new',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/logout/index.js
+++ b/routes/admin/authenticated/logout/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /logout
+//
 export default store => ({
   path: 'logout',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/account-edit/index.js
+++ b/routes/admin/authenticated/sidebar/account-edit/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /account/edit
+//
 export default store => ({
   path: 'account/edit',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/blocks-create/index.js
+++ b/routes/admin/authenticated/sidebar/blocks-create/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/blocks/create
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/blocks/create',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/community-settings/domain-create/index.js
+++ b/routes/admin/authenticated/sidebar/community-settings/domain-create/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /community/domain/add
+//
 export default store => ({
   path: 'domain/add',
 

--- a/routes/admin/authenticated/sidebar/community-settings/domain/index.js
+++ b/routes/admin/authenticated/sidebar/community-settings/domain/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /community/domain
+//
 export default store => ({
   path: 'domain',
 

--- a/routes/admin/authenticated/sidebar/community-settings/info/index.js
+++ b/routes/admin/authenticated/sidebar/community-settings/info/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /community/info
+//
 export default store => ({
   path: 'info',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/community-settings/mailchimp/index.js
+++ b/routes/admin/authenticated/sidebar/community-settings/mailchimp/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /community/mailchimp
+//
 export default store => ({
   path: 'mailchimp',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/community-settings/recipient/index.js
+++ b/routes/admin/authenticated/sidebar/community-settings/recipient/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /community/recipient
+//
 export default store => ({
   path: 'recipient',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/community-settings/report/index.js
+++ b/routes/admin/authenticated/sidebar/community-settings/report/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /community/report
+//
 export default store => ({
   path: 'report',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/mobilizations-edit/index.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-edit/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/edit
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/edit',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/mobilizations-launch-end/index.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-launch-end/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/launch/end
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/launch/end',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/mobilizations-launch/index.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-launch/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/launch
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/launch',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/mobilizations-launch/page.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-launch/page.js
@@ -95,12 +95,14 @@ const MobilizationsLaunchPage = ({ hostedZones, mobilization, isSaving, ...formP
           <div className='ux--flat-form'>
             <h1>Seu BONDE está pronto!</h1>
             <p className='h5'>
-            Em uma nova aba, digite o endereço que cadastrou na mobilização
-            para se certificar de que ela já está no ar. Se ainda não estiver,
-            cheque se cadastrou os domínios corretamente. Está tudo certo? Então
-            é só esperar ele propagar pela internet!
+              Em uma nova aba, digite o endereço que cadastrou na mobilização
+              para se certificar de que ela já está no ar. Se ainda não estiver,
+              cheque se cadastrou os domínios corretamente. Está tudo certo? Então
+              é só esperar ele propagar pela internet!
             </p>
-            <Button href={`http://${mobilization.custom_domain}`} target='_blank'>Visualizar mobilização</Button>
+            <Button href={`http://${mobilization.custom_domain}`} target='_blank'>
+              Visualizar mobilização
+            </Button>
           </div>
         </StepContent>
       </StepsContainerStack>

--- a/routes/admin/authenticated/sidebar/mobilizations-list/index.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-list/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations
+//
 export default store => ({
   path: 'mobilizations',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/mobilizations-new/index.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-new/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/new
+//
 export default store => ({
   path: 'mobilizations/new',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/mobilizations-settings-analytics/index.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-settings-analytics/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/analytics
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/analytics',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/mobilizations-settings-basics/index.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-settings-basics/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/basics
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/basics',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/mobilizations-settings-domain/index.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-settings-domain/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/customDomain
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/customDomain',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/mobilizations-settings-sharing/index.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-settings-sharing/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/sharing
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/sharing',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/templates-choose-custom/index.js
+++ b/routes/admin/authenticated/sidebar/templates-choose-custom/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/templates/choose/custom
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/templates/choose/custom',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/templates-choose-global/index.js
+++ b/routes/admin/authenticated/sidebar/templates-choose-global/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/templates/choose/global
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/templates/choose/global',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/templates-choose-global/page.js
+++ b/routes/admin/authenticated/sidebar/templates-choose-global/page.js
@@ -13,7 +13,7 @@ const TemplatesChooseGlobalPage = ({
 }) => (
   <PageTabLayout {...{ location }}>
     <div className='choose-global-page col-12'>
-      <h3 className='h1 mt0 mb3 center'>Meus Templates</h3>
+      <h3 className='h1 mt0 mb3 center'>Templates Globais</h3>
       <TemplateSelectableList
         {...listableProps}
         handleGoBack={() => browserHistory.push(paths.mobilizationTemplatesChoose(mobilization))}

--- a/routes/admin/authenticated/sidebar/templates-choose/index.js
+++ b/routes/admin/authenticated/sidebar/templates-choose/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/templates/choose
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/templates/choose',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/templates-create/index.js
+++ b/routes/admin/authenticated/sidebar/templates-create/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/templates/create
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/templates/create',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/templates-list/index.js
+++ b/routes/admin/authenticated/sidebar/templates-list/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/templates/list
+//
 export default store => ({
   path: 'mobilizations/templates/list',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-donation-settings/autofire/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-donation-settings/autofire/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/donation/autofire
+//
 export default store => ({
   path: 'autofire',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-donation-settings/export/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-donation-settings/export/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/donation/export
+//
 export default store => ({
   path: 'export',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-donation-settings/finish/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-donation-settings/finish/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/donation/finish
+//
 export default store => ({
   path: 'finish',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-donation-settings/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-donation-settings/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/donation
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/widgets/:widget_id/donation',
   getIndexRoute (location, cb) {

--- a/routes/admin/authenticated/sidebar/widgets-form-settings/autofire/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-form-settings/autofire/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/form/autofire
+//
 export default store => ({
   path: 'autofire',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-form-settings/export/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-form-settings/export/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/form/export
+//
 export default store => ({
   path: 'export',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-form-settings/fields/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-form-settings/fields/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/form/fields
+//
 export default store => ({
   path: 'fields',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-form-settings/finish/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-form-settings/finish/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/form/finish
+//
 export default store => ({
   path: 'finish',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-form-settings/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-form-settings/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/form
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/widgets/:widget_id/form',
   getIndexRoute (location, cb) {

--- a/routes/admin/authenticated/sidebar/widgets-pressure-settings/autofire/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-pressure-settings/autofire/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/pressure/autofire
+//
 export default store => ({
   path: 'autofire',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-pressure-settings/email/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-pressure-settings/email/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/pressure/email
+//
 export default store => ({
   path: 'email',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-pressure-settings/finish/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-pressure-settings/finish/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
+//
 export default store => ({
   path: 'finish',
   getComponent (nextState, callback) {

--- a/routes/admin/authenticated/sidebar/widgets-pressure-settings/index.js
+++ b/routes/admin/authenticated/sidebar/widgets-pressure-settings/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /mobilizations/:mobilization_id/widgets/:widget_id/pressure
+//
 export default store => ({
   path: 'mobilizations/:mobilization_id/widgets/:widget_id/pressure',
   getIndexRoute (location, cb) {

--- a/routes/admin/index.js
+++ b/routes/admin/index.js
@@ -1,12 +1,13 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
-// import { injectAsyncReducer } from '~client/store'
-// import { showMobilizationPublicView, getDomain } from '~routes/utils'
 import { isIndexRedirected } from '~routes/utils'
 
+//
+// @path (admin) /
+//
 export default store => ({
   path: '/',
-  //
+
   indexRoute: {
     onEnter: isIndexRedirected(store)
   },

--- a/routes/admin/not-authenticated/account-login/index.js
+++ b/routes/admin/not-authenticated/account-login/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /login
+//
 export default store => ({
   path: 'login',
   getComponent (nextState, callback) {
@@ -11,27 +14,3 @@ export default store => ({
     })
   }
 })
-
-// import React from 'react'
-// import { Route } from 'react-router'
-//
-// import { BackgroundContainer } from '../Dashboard/containers'
-// import { SidebarContainer } from '~client/components/navigation/sidebar'
-//
-// import {
-//   EditUserPage,
-//   LoginPageWrapper,
-//   LogoutPage,
-//   RegisterPage
-// } from './pages'
-//
-// export default (requiredLogin, redirectUrl) => [
-//   <Route key='account' component={BackgroundContainer}>
-//     <Route path='/login' component={LoginPageWrapper(redirectUrl)} />
-//     <Route path='/logout' component={LogoutPage} />
-//     <Route path='/register' component={RegisterPage} />
-//   </Route>,
-//   <Route key='account-logged' path='/account' component={SidebarContainer} onEnter={requiredLogin}>
-//     <Route path='/edit' component={EditUserPage} />
-//   </Route>
-// ]

--- a/routes/admin/not-authenticated/account-register/index.js
+++ b/routes/admin/not-authenticated/account-register/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (admin) /register
+//
 export default store => ({
   path: 'register',
   getComponent (nextState, callback) {

--- a/routes/admin/not-authenticated/playground-js/index.js
+++ b/routes/admin/not-authenticated/playground-js/index.js
@@ -1,6 +1,9 @@
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 
+//
+// @path (admin) /playground-js
+//
 export default store => ({
   path: 'playground-js',
   getComponent (nextState, callback) {

--- a/routes/public/custom-domain/index.js
+++ b/routes/public/custom-domain/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (public) /
+//
 export default store => ({
   path: '/',
 

--- a/routes/public/subscription-edit/index.js
+++ b/routes/public/subscription-edit/index.js
@@ -2,6 +2,9 @@
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require)
 import { injectAsyncReducer } from '~client/store'
 
+//
+// @path (public) /subscriptions/:id/edit
+//
 export default store => ({
   path: 'subscriptions/:id/edit',
   getComponent (nextState, callback) {


### PR DESCRIPTION
# Related issues
- Create a default pt-BR file with all keys #614

# How to test
- Included a new npm script that you can run it with `yarn routes` or `npm run routes`. This command will list all route paths in the application. But, to this command works well, each new route config file must have a comment like [this](https://github.com/nossas/bonde-client/blob/123c19eac128f54b6408c6eff09624be450ff16c/routes/admin/authenticated/external/community-list/index.js#L5-L7)
- The translation keys do not have a testing case, because it will be used after in the components.