### PR TITLE
Feature community recipient pagarme warning message

### DIFF
--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -241,6 +241,8 @@ export default {
   // page community recipient
   // filepath: /routes/admin/authenticated/sidebar/community-settings/recipient/page.js
   // routepath: /community/recipient
+  'page--community-recipient.pagarme-warning': 'Atenção: As doações só ficam disponíveis 31 dias após a transação de cartão de crédito ter sido criada (29 dias corridos + 2 dias úteis) no caso de transações com uma parcela e 2 dias úteis após o pagamento do boleto bancário. Caso a transação tenha de 2 a 12 parcelas, o recebimento normal será da seguinte forma: primeira parcela em 31 dias, segunda em 61, terceira em 91, e assim por diante.',
+
   'page--community-recipient.form.transfer-interval.label': 'Intervalo',
   'page--community-recipient.form.transfer-interval.value.weekly': 'Semanalmente',
   'page--community-recipient.form.transfer-interval.value.monthly': 'Mensalmente',

--- a/routes/admin/authenticated/sidebar/community-settings/recipient/page.js
+++ b/routes/admin/authenticated/sidebar/community-settings/recipient/page.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
 import uuid from 'uuid'
 
 import {
@@ -25,6 +26,19 @@ const CommunitySettingsRecipientPage = ({
   ...formProps
 }) => (
   <SettingsForm {...formProps}>
+    <p style={{ color: '#FF9500' }}>
+      <FormattedMessage
+        id='page--community-recipient.pagarme-warning'
+        defaultMessage={
+          'Atenção: As doações só ficam disponíveis 31 dias após a transação de cartão de ' +
+          'crédito ter sido criada (29 dias corridos + 2 dias úteis) no caso de transações ' +
+          'com uma parcela e 2 dias úteis após o pagamento do boleto bancário. Caso a ' +
+          'transação tenha de 2 a 12 parcelas, o recebimento normal será da seguinte ' +
+          'forma: primeira parcela em 31 dias, segunda em 61, terceira em 91, ' +
+          'e assim por diante.'
+        }
+      />
+    </p>
     <FormGroup controlId='transferIntervalId' {...transferInterval}>
       <ControlLabel>Intervalo</ControlLabel>
       <RadioGroup layout='horizontal'>


### PR DESCRIPTION
# Related issues
- Add warning when configure pagarme details at community options #628

# How to test
- Access the `/community/recipient` route
- A warning message should be shown like screenshot below:
<img width="1288" alt="screen shot 2017-05-30 at 16 00 18" src="https://cloud.githubusercontent.com/assets/5435389/26600223/a968689c-4551-11e7-9b3a-8179160e4e89.png">
