### PR TITLE
Hotfix slate editor v2.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "redux-logger": "^2.7.4",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.1.0",
-    "slate-editor": "2.6.2",
+    "slate-editor": "2.6.3",
     "superagent": "^3.3.2",
     "throng": "^4.0.0",
     "url-loader": "^0.5.8",

--- a/routes/admin/authenticated/sidebar/community-settings/recipient/page.js
+++ b/routes/admin/authenticated/sidebar/community-settings/recipient/page.js
@@ -26,7 +26,14 @@ const CommunitySettingsRecipientPage = ({
   ...formProps
 }) => (
   <SettingsForm {...formProps}>
-    <p style={{ color: '#FF9500' }}>
+    <p
+      style={{
+        color: '#444',
+        fontWeight: 'bold',
+        background: '#eee',
+        padding: '1em'
+      }}
+    >
       <FormattedMessage
         id='page--community-recipient.pagarme-warning'
         defaultMessage={

--- a/yarn.lock
+++ b/yarn.lock
@@ -7339,9 +7339,9 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate-editor@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/slate-editor/-/slate-editor-2.6.2.tgz#70d712ae384f6624afe3825f3090c129a9beefdf"
+slate-editor@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/slate-editor/-/slate-editor-2.6.3.tgz#6c245cea9b678b0d5b70289c1fec0160e6b13544"
   dependencies:
     classnames "^2.2.5"
     exenv "^1.2.1"


### PR DESCRIPTION
# How to test

### Editor
- Access a mobilization e.g. http://www.370-esp-instinto-de-vida.staging.bonde.org/
- The images that contains legacy **link** + **image** nested nodes, should not have the border style

### Community Recipient
- Access http://app.staging.bonde.org/community/recipient
- The pagarme warning text should be more readable