### PR TITLE
Feature improve mobilization domain options

### DIFF
--- a/client/components/forms/form-dropdown.js
+++ b/client/components/forms/form-dropdown.js
@@ -17,8 +17,8 @@ class FormDropdown extends Component {
       <select
         id={controlId}
         className={classnames('select col-12', className)}
-        {...props}
         {...field}
+        {...props}
       >
         {!!children && children}
       </select>

--- a/client/mobilizations/components/form-domain.connected.js
+++ b/client/mobilizations/components/form-domain.connected.js
@@ -5,7 +5,14 @@ import { asyncUpdateMobilization } from '~client/mobrender/redux/action-creators
 import { isValidDomain } from '~client/utils/validation-helper'
 import FormDomain from './form-domain'
 
-const fields = ['advancedConfig', 'domain', 'subdomain', 'externalDomain']
+const fields = [
+  'advancedConfig',
+  'domain',
+  'subdomain',
+  'externalDomain',
+  'rootDomain',
+  'rootDomainConfig'
+]
 
 export const validate = (values, props) => {
   const errors = {}
@@ -14,14 +21,22 @@ export const validate = (values, props) => {
     if (values.advancedConfig === true && !values.externalDomain) {
       errors.externalDomain = 'Obrigatório'
     }
-    if (!values.advancedConfig && !values.subdomain) {
-      errors.subdomain = 'Obrigatório'
-    }
-    if (!values.advancedConfig && !values.domain) {
-      errors.domain = 'Obrigatório'
+    if (!values.rootDomainConfig) {
+      if (!values.advancedConfig && !values.subdomain) {
+        errors.subdomain = 'Obrigatório'
+      }
+      if (!values.advancedConfig && !values.domain) {
+        errors.domain = 'Obrigatório'
+      }
     }
   }
 
+  if (!values.rootDomainConfig && !values.advancedConfig && !values.domain) {
+    errors.domain = 'Obrigatório'
+  }
+  if (values.rootDomainConfig && !values.rootDomain) {
+    errors.rootDomain = 'Obrigatório'
+  }
   if (values.externalDomain && !isValidDomain(values.externalDomain)) {
     errors.externalDomain = 'Informe um domínio válido'
   }
@@ -33,42 +48,68 @@ const mapStateToProps = (state, props) => {
   const { custom_domain: customDomain } = props.mobilization
   if (customDomain) {
     const hasWWW = customDomain.startsWith('www.')
-    // eslint-disable-next-line no-useless-escape
+    /* eslint-disable no-useless-escape */
     const reDomain = hasWWW ? /^www.[\w\-]+\.(.*)/ : /^[\w\-]+\.(.*)/
     const reSubdomain = hasWWW ? /^www\.([\w-]*).[\w-.]*/ : /^([\w-]*).[\w-.]*/
+    const rootDomainRegex = zone => new RegExp(`^www\.${zone.domain_name}$`).test(customDomain)
+    /* eslint-disable no-useless-escape */
 
     const domain = customDomain.match(reDomain)[1]
     const subdomain = customDomain.match(reSubdomain)[1]
+
+    if (props.hostedZones.some(rootDomainRegex)) {
+      return {
+        initialValues: {
+          rootDomain: customDomain.replace(/^www\./, ''),
+          rootDomainConfig: true,
+          advancedConfig: false
+        }
+      }
+    }
     if (props.hostedZones.find(h => h.domain_name === domain) !== undefined) {
       return {
-        initialValues: { domain, subdomain, advancedConfig: false }
+        initialValues: { domain, subdomain, advancedConfig: false, rootDomainConfig: false }
       }
     }
     return {
       initialValues: {
         externalDomain: hasWWW ? customDomain.replace('www.', '') : customDomain,
-        advancedConfig: true
+        advancedConfig: true,
+        rootDomainConfig: false
       }
     }
   }
   return {
-    initialValues: {
-      domain: props.hostedZones.length > 0 ? props.hostedZones[0].domain_name : undefined
-    }
+    initialValues: {}
   }
 }
 
 const mapActionsToProps = (dispatch, props) => ({
   ...props,
-  submit: ({ advancedConfig, domain, subdomain, externalDomain }) => {
-    const mobilization = { ...props.mobilization, custom_domain: null }
-    if (advancedConfig && externalDomain) {
-      const www = externalDomain.startsWith('www.')
-      mobilization.custom_domain = www ? externalDomain : `www.${externalDomain}`
-    } else if (!advancedConfig && subdomain) {
-      const www = subdomain.startsWith('www.')
-      mobilization.custom_domain = www ? `${subdomain}.${domain}` : `www.${subdomain}.${domain}`
+  submit: ({
+    advancedConfig,
+    domain,
+    subdomain,
+    externalDomain,
+    rootDomainConfig,
+    rootDomain
+  }) => {
+    let customDomain = null
+    const mobilization = { ...props.mobilization, custom_domain: customDomain }
+
+    const isRoot = rootDomainConfig && rootDomain
+    const isExternal = advancedConfig && externalDomain
+    const isSubdomain = !advancedConfig && subdomain
+
+    if (isRoot) customDomain = rootDomain
+    else if (isExternal) customDomain = externalDomain
+    else if (isSubdomain) customDomain = `${subdomain}.${domain}`
+
+    if (customDomain) {
+      const www = customDomain.startsWith('www.')
+      mobilization.custom_domain = www ? customDomain : `www.${customDomain}`
     }
+
     return dispatch(asyncUpdateMobilization(mobilization))
   }
 })

--- a/client/mobilizations/components/form-domain.js
+++ b/client/mobilizations/components/form-domain.js
@@ -16,6 +16,16 @@ const HeaderToggle = ({ children, show, onToggle }) => (
   </h3>
 )
 
+const CreateDomainText = ({ onClickLink }) => (
+  <p className='h5'>
+    Ops, você ainda não tem um domínio configurado na sua comunidade. Se quiser
+    cadastar, <a href='#' onClick={onClickLink} target='_self'>clique aqui</a>.
+    <br />
+    Senão você pode, abaixo, usar um domínio externo para configurar o endereço
+    da sua mobilização.
+  </p>
+)
+
 class FormDomain extends Component {
 
   constructor (props) {
@@ -41,11 +51,23 @@ class FormDomain extends Component {
     if (key === 'showExternalDomain') {
       this.props.fields.advancedConfig.onChange(value)
       const state = { [key]: value }
-      if (value === true) state.showSubdomain = false
+      if (value === true) {
+        state.showSubdomain = false
+        state.showRootDomain = false
+      }
       this.setState(state)
     } else if (key === 'showSubdomain') {
       const state = { [key]: value }
       if (value === true) {
+        state.showExternalDomain = false
+        state.showRootDomain = false
+        this.props.fields.advancedConfig.onChange(false)
+      }
+      this.setState(state)
+    } else if (key === 'showRootDomain') {
+      const state = { [key]: value }
+      if (value === true) {
+        state.showSubdomain = false
         state.showExternalDomain = false
         this.props.fields.advancedConfig.onChange(false)
       }
@@ -110,9 +132,7 @@ class FormDomain extends Component {
               onToggle={() => this.toggle('showSubdomain', !this.state.showSubdomain)}
               show={this.state.showSubdomain}
             >
-              {hostedZones.length > 0
-                ? `Quero usar o domínio principal da minha comunidade`
-                : `Quero cadastrar um domínio principal na minha comunidade`}
+              Quero usar um novo sub-domínio
             </HeaderToggle>
             {this.state.showSubdomain && (
               hostedZones.length > 0 ? (
@@ -147,12 +167,56 @@ class FormDomain extends Component {
                 </div>
               ) : (
                 <div>
+                  <CreateDomainText
+                    onClickLink={this.clickHere.bind(this)}
+                  />
+                </div>
+              )
+            )}
+          </div>
+          <div className='root-domain-config' style={{ marginBottom: '1rem' }}>
+            <HeaderToggle
+              onToggle={() => this.toggle('showRootDomain', !this.state.showRootDomain)}
+              show={this.state.showRootDomain}
+            >
+              Quero usar um domínio principal cadastrado na comunidade
+            </HeaderToggle>
+            {this.state.showRootDomain && (
+              hostedZones.length > 0 ? (
+                <div>
                   <p className='h5'>
-                    Ops, você ainda não tem um domínio configurado na sua comunidade. Se quiser
-                    cadastar, <a href='#' onClick={this.clickHere.bind(this)} target='_self'>clique aqui</a>.
-                    Senão você pode, abaixo, usar um domínio externo para configurar o endereço
-                    da sua mobilização.
+                    Preencha abaixo o subdomínio e escolha o domínio que deseja
+                    configurar como endereço da sua mobilização
                   </p>
+                  <div className='form-groups-container flex flex-wrap'>
+                    <div className='prefix'>www.</div>
+                    <FormGroup controlId='subdomain' {...subdomain}>
+                      <ControlLabel>Subdomínio</ControlLabel>
+                      <FormControl
+                        type='text'
+                        placeholder='nomedamob'
+                      />
+                    </FormGroup>
+                    <div className='delimiter'>
+                      <strong>.</strong>
+                    </div>
+                    <FormGroup controlId='domain' {...domain}>
+                      <ControlLabel>Domínio Principal</ControlLabel>
+                      <FormDropdown>
+                        {hostedZones.map((obj, i) => (
+                          <option key={`hostedZone-${i}`} value={obj.domain_name}>
+                            {obj.domain_name}
+                          </option>
+                        ))}
+                      </FormDropdown>
+                    </FormGroup>
+                  </div>
+                </div>
+              ) : (
+                <div>
+                  <CreateDomainText
+                    onClickLink={this.clickHere.bind(this)}
+                  />
                 </div>
               )
             )}
@@ -162,7 +226,7 @@ class FormDomain extends Component {
               onToggle={() => this.toggle('showExternalDomain', !this.state.showExternalDomain)}
               show={this.state.showExternalDomain}
             >
-              Quero usar um domínio externo
+              Quero direcionar para um domínio externo
             </HeaderToggle>
 
             {this.state.showExternalDomain && (

--- a/client/mobilizations/components/form-domain.js
+++ b/client/mobilizations/components/form-domain.js
@@ -149,13 +149,14 @@ class FormDomain extends Component {
       <div className='components--form-domain'>
         <FormComponent {...formProps}>
           <p className='h5 mb3'>
-            Estamos quase lá, agora você precisa escolher qual endereço será utilizado.
+            Estamos quase lá, antes de publicar sua mobilização é preciso
+            escolher a url que será usada para publicação.
             <br />
-            Se você já cadastrou um domínio na comunidade, pode selecionar abaixo qual das
-            opções melhor se encaixa!
+            Já cadastrou um domínio na comunidade? Selecione abaixo qual
+            das opções melhor se encaixa.
             <br />
-            Para fazer o cadastro de um novo
-            domínio, <a href='#' onClick={this.clickHere.bind(this)} target='_self'>clique aqui</a>.
+            Quer cadastrar um novo
+            domínio? <a href='#' onClick={this.clickHere.bind(this)} target='_self'>Clique aqui</a>.
           </p>
 
           <div className='basic-config' style={{ marginBottom: '1rem' }}>

--- a/client/mobilizations/components/form-domain.js
+++ b/client/mobilizations/components/form-domain.js
@@ -147,17 +147,17 @@ class FormDomain extends Component {
 
     return (
       <div className='components--form-domain'>
-        <p className='h5 mb3'>
-          Estamos quase lá, agora você precisa escolher qual endereço será utilizado.
-          <br />
-          Se você já cadastrou um domínio na comunidade, pode selecionar abaixo qual das
-          opções melhor se encaixa!
-          <br />
-          Para fazer o cadastro de um novo
-          domínio, <a href='#' onClick={this.clickHere.bind(this)} target='_self'>clique aqui</a>.
-        </p>
-
         <FormComponent {...formProps}>
+          <p className='h5 mb3'>
+            Estamos quase lá, agora você precisa escolher qual endereço será utilizado.
+            <br />
+            Se você já cadastrou um domínio na comunidade, pode selecionar abaixo qual das
+            opções melhor se encaixa!
+            <br />
+            Para fazer o cadastro de um novo
+            domínio, <a href='#' onClick={this.clickHere.bind(this)} target='_self'>clique aqui</a>.
+          </p>
+
           <div className='basic-config' style={{ marginBottom: '1rem' }}>
             <HeaderToggle
               onToggle={() => this.toggle('showSubdomain', !this.state.showSubdomain)}

--- a/client/mobilizations/components/form-domain.js
+++ b/client/mobilizations/components/form-domain.js
@@ -147,6 +147,16 @@ class FormDomain extends Component {
 
     return (
       <div className='components--form-domain'>
+        <p className='h5 mb3'>
+          Estamos quase lá, agora você precisa escolher qual endereço será utilizado.
+          <br />
+          Se você já cadastrou um domínio na comunidade, pode selecionar abaixo qual das
+          opções melhor se encaixa!
+          <br />
+          Para fazer o cadastro de um novo
+          domínio, <a href='#' onClick={this.clickHere.bind(this)} target='_self'>clique aqui</a>.
+        </p>
+
         <FormComponent {...formProps}>
           <div className='basic-config' style={{ marginBottom: '1rem' }}>
             <HeaderToggle

--- a/client/mobilizations/components/form-domain.js
+++ b/client/mobilizations/components/form-domain.js
@@ -27,18 +27,24 @@ const CreateDomainText = ({ onClickLink }) => (
 )
 
 class FormDomain extends Component {
-
   constructor (props) {
     super(props)
-    this.state = { showSubdomain: false, showExternalDomain: false }
-  }
 
-  componentDidMount () {
-    const { fields: { subdomain, externalDomain } } = this.props
-    if (subdomain.value) {
-      this.toggle('showSubdomain', true)
-    } else if (externalDomain.value) {
-      this.toggle('showExternalDomain', true)
+    const { hostedZones, mobilization: { custom_domain: customDomain } } = props
+
+    /* eslint-disable no-useless-escape */
+    const subdomainRegex = zone => new RegExp(`^www\..+\.${zone.domain_name}$`).test(customDomain)
+    const rootDdomainRegex = zone => new RegExp(`^www\.${zone.domain_name}$`).test(customDomain)
+    /* eslint-disable no-useless-escape */
+
+    const hasCustomDomain = !!customDomain
+    const isSubdomain = hostedZones.some(subdomainRegex)
+    const isRootDomain = hostedZones.some(rootDdomainRegex)
+
+    this.state = {
+      showSubdomain: !hasCustomDomain || isSubdomain,
+      showExternalDomain: hasCustomDomain && !isSubdomain && !isRootDomain,
+      showRootDomain: isRootDomain
     }
   }
 
@@ -188,29 +194,6 @@ class FormDomain extends Component {
                     Preencha abaixo o subdomínio e escolha o domínio que deseja
                     configurar como endereço da sua mobilização
                   </p>
-                  <div className='form-groups-container flex flex-wrap'>
-                    <div className='prefix'>www.</div>
-                    <FormGroup controlId='subdomain' {...subdomain}>
-                      <ControlLabel>Subdomínio</ControlLabel>
-                      <FormControl
-                        type='text'
-                        placeholder='nomedamob'
-                      />
-                    </FormGroup>
-                    <div className='delimiter'>
-                      <strong>.</strong>
-                    </div>
-                    <FormGroup controlId='domain' {...domain}>
-                      <ControlLabel>Domínio Principal</ControlLabel>
-                      <FormDropdown>
-                        {hostedZones.map((obj, i) => (
-                          <option key={`hostedZone-${i}`} value={obj.domain_name}>
-                            {obj.domain_name}
-                          </option>
-                        ))}
-                      </FormDropdown>
-                    </FormGroup>
-                  </div>
                 </div>
               ) : (
                 <div>

--- a/client/utils/type-checker.js
+++ b/client/utils/type-checker.js
@@ -1,0 +1,1 @@
+export const isBoolean = value => value.constructor === Boolean

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -590,6 +590,11 @@ export default {
   // routepath:
   //   - /mobilizations/:mobilization_id/customDomain
   //   - /mobilizations/:mobilization_id/launch
+  'mobilizations.components--form-domain.helper-text-first-line': 'Estamos quase lá, agora você precisa escolher qual endereço será utilizado.',
+  'mobilizations.components--form-domain.helper-text-second-line': 'Se você já cadastrou um domínio na comunidade, pode selecionar abaixo qual das opções melhor se encaixa!',
+  'mobilizations.components--form-domain.helper-text-third-line': 'Para fazer o cadastro de um novo domínio, {link}.',
+  'mobilizations.components--form-domain.helper-text-third-line.link': 'clique aqui',
+
   'mobilizations.components--form-domain.create-domain-text.first-line': 'Ops, você ainda não tem um domínio configurado na sua comunidade. Se quiser cadastar, {link}.',
   'mobilizations.components--form-domain.create-domain-text.first-line.link': 'clique aqui',
   'mobilizations.components--form-domain.create-domain-text.second-line': 'Senão você pode, abaixo, usar um domínio externo para configurar o endereço da sua mobilização.',

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -601,6 +601,7 @@ export default {
   'mobilizations.components--form-domain.basic.form.domain.label': 'Domínio Principal',
 
   'mobilizations.components--form-domain.root.header-toggle.use-root-domain': 'Quero usar um domínio principal cadastrado na comunidade',
+  'mobilizations.components--form-domain.root.helper-text': 'Escolha o domínio que deseja configurar como endereço da sua mobilização',
 
   'mobilizations.components--form-domain.advanced.header-toggle': 'Quero direcionar para um domínio externo',
   'mobilizations.components--form-domain.advanced.helper-text': 'Se você quer usar um domínio que comprou mas não está cadastrado na sua comunidade aqui, pode fazer isso. Por exemplo, se você já comprou www.meudominio.com.br você pode usá-lo para este BONDE. Demais, né? Preencha o campo abaixo e siga as orientações:',

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -590,10 +590,10 @@ export default {
   // routepath:
   //   - /mobilizations/:mobilization_id/customDomain
   //   - /mobilizations/:mobilization_id/launch
-  'mobilizations.components--form-domain.helper-text-first-line': 'Estamos quase lá, agora você precisa escolher qual endereço será utilizado.',
-  'mobilizations.components--form-domain.helper-text-second-line': 'Se você já cadastrou um domínio na comunidade, pode selecionar abaixo qual das opções melhor se encaixa!',
-  'mobilizations.components--form-domain.helper-text-third-line': 'Para fazer o cadastro de um novo domínio, {link}.',
-  'mobilizations.components--form-domain.helper-text-third-line.link': 'clique aqui',
+  'mobilizations.components--form-domain.helper-text-first-line': 'Estamos quase lá, antes de publicar sua mobilização é preciso escolher a url que será usada para publicação.',
+  'mobilizations.components--form-domain.helper-text-second-line': 'Já cadastrou um domínio na comunidade? Selecione abaixo qual das opções melhor se encaixa.',
+  'mobilizations.components--form-domain.helper-text-third-line': 'Quer cadastrar um novo domínio? {link}.',
+  'mobilizations.components--form-domain.helper-text-third-line.link': 'Clique aqui',
 
   'mobilizations.components--form-domain.create-domain-text.first-line': 'Ops, você ainda não tem um domínio configurado na sua comunidade. Se quiser cadastar, {link}.',
   'mobilizations.components--form-domain.create-domain-text.first-line.link': 'clique aqui',

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -590,16 +590,19 @@ export default {
   // routepath:
   //   - /mobilizations/:mobilization_id/customDomain
   //   - /mobilizations/:mobilization_id/launch
-  'mobilizations.components--form-domain.basic.header-toggle.use-existing-domain': 'Quero usar o domínio principal da minha comunidade',
-  'mobilizations.components--form-domain.basic.header-toggle.create-domain': 'Quero cadastrar um domínio principal na minha comunidade',
+  'mobilizations.components--form-domain.create-domain-text.first-line': 'Ops, você ainda não tem um domínio configurado na sua comunidade. Se quiser cadastar, {link}.',
+  'mobilizations.components--form-domain.create-domain-text.first-line.link': 'clique aqui',
+  'mobilizations.components--form-domain.create-domain-text.second-line': 'Senão você pode, abaixo, usar um domínio externo para configurar o endereço da sua mobilização.',
+
+  'mobilizations.components--form-domain.basic.header-toggle.use-existing-domain': 'Quero usar um novo sub-domínio',
   'mobilizations.components--form-domain.basic.helper-text': 'Preencha abaixo o subdomínio e escolha o domínio que deseja configurar como endereço da sua mobilização',
   'mobilizations.components--form-domain.basic.form.subdomain.label': 'Subdomínio',
   'mobilizations.components--form-domain.basic.form.subdomain.placeholder': 'nomedamob',
   'mobilizations.components--form-domain.basic.form.domain.label': 'Domínio Principal',
-  'mobilizations.components--form-domain.basic.create-domain.helper-text': 'Ops, você ainda não tem um domínio configurado na sua comunidade. Se quiser cadastar, {link}. Senão você pode, abaixo, usar um domínio externo para configurar o endereço da sua mobilização.',
-  'mobilizations.components--form-domain.basic.create-domain.helper-text.link': 'clique aqui',
 
-  'mobilizations.components--form-domain.advanced.header-toggle': 'Quero usar um domínio externo',
+  'mobilizations.components--form-domain.root.header-toggle.use-root-domain': 'Quero usar um domínio principal cadastrado na comunidade',
+
+  'mobilizations.components--form-domain.advanced.header-toggle': 'Quero direcionar para um domínio externo',
   'mobilizations.components--form-domain.advanced.helper-text': 'Se você quer usar um domínio que comprou mas não está cadastrado na sua comunidade aqui, pode fazer isso. Por exemplo, se você já comprou www.meudominio.com.br você pode usá-lo para este BONDE. Demais, né? Preencha o campo abaixo e siga as orientações:',
   'mobilizations.components--form-domain.advanced.form.external-domain.label': 'Domínio personalizado',
   'mobilizations.components--form-domain.advanced.form.external-domain.placeholder': 'meudominio.com.br',

--- a/routes/admin/authenticated/sidebar/mobilizations-launch/form-domain.scss
+++ b/routes/admin/authenticated/sidebar/mobilizations-launch/form-domain.scss
@@ -1,0 +1,8 @@
+.components--form-domain {
+  .ux--flat-form {
+    .basic-config .form-groups-container {
+      .prefix { margin-right: 9px; }
+      .delimiter { margin: 0 8px; }
+    }
+  }
+}

--- a/routes/admin/authenticated/sidebar/mobilizations-launch/page.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-launch/page.js
@@ -12,6 +12,7 @@ import { StepsContainerStack, StepContent } from '~client/components/steps'
 import { FormDomain, FormShare } from '~client/mobilizations/components'
 
 if (require('exenv').canUseDOM) {
+  require('./form-domain.scss')
   require('./form-share.scss')
 }
 


### PR DESCRIPTION
# Related issues
- Improvements when user choose howto publish mobilization #629

# How to test
Test cases by domain configuration options

## Subdomain configuration
- Access the mobilization domain settings page
- If the mobilization does not have a custom domain configured yet, you should see the first option opened by default (subdomain configuration), as you can see in the screenshot below:
<img width="743" alt="screen shot 2017-06-01 at 04 53 15" src="https://cloud.githubusercontent.com/assets/5435389/26670020/627c1aec-4686-11e7-86aa-4a7cd42232e8.png">
- Same in the mobilization's launch page:
<img width="497" alt="screen shot 2017-06-01 at 04 55 18" src="https://cloud.githubusercontent.com/assets/5435389/26670061/952cc414-4686-11e7-936f-88780984850d.png">
- If the mobilization already have a custom domain configured, this section should the opened by default.

## Root domain configuration
- Access the mobilization domain settings page
- If the mobilization already have a custom domain configured, this section should the opened by default.
- Click on the second option **Quero usar um domínio principal cadastrado na comunidade**
- You should see a form like screenshot below:
<img width="716" alt="screen shot 2017-06-01 at 04 58 47" src="https://cloud.githubusercontent.com/assets/5435389/26670170/05a20c2c-4687-11e7-8ec5-3f2321a44bfd.png">
- Same in the mobilization's launch page:
<img width="496" alt="screen shot 2017-06-01 at 04 58 36" src="https://cloud.githubusercontent.com/assets/5435389/26670175/0be7331e-4687-11e7-9bc7-b988c22532c8.png">

## External domain configuration
- Access the mobilization domain settings page
- If the mobilization already have a custom domain configured, this section should the opened by default.
- Click on the third option **Quero direcionar para um domínio externo**
- You should see a form like screenshot below:
<img width="1167" alt="screen shot 2017-06-01 at 04 59 50" src="https://cloud.githubusercontent.com/assets/5435389/26670227/3f821770-4687-11e7-88cf-e67fe2c62e41.png">
- Same in the mobilization's launch page:
<img width="498" alt="screen shot 2017-06-01 at 05 00 04" src="https://cloud.githubusercontent.com/assets/5435389/26670232/47d7764a-4687-11e7-9406-926674d16420.png">
