### PR TITLE
Upgrade slate-editor to v2.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "redux-logger": "^2.7.4",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.1.0",
-    "slate-editor": "2.6.3",
+    "slate-editor": "2.6.4",
     "superagent": "^3.3.2",
     "throng": "^4.0.0",
     "url-loader": "^0.5.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7339,9 +7339,9 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate-editor@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/slate-editor/-/slate-editor-2.6.3.tgz#6c245cea9b678b0d5b70289c1fec0160e6b13544"
+slate-editor@2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/slate-editor/-/slate-editor-2.6.4.tgz#2a73152ed0fee5136fbab6bdeb6c654391082549"
   dependencies:
     classnames "^2.2.5"
     exenv "^1.2.1"


### PR DESCRIPTION
# Description
remove the link plugin's modal form validation, that allows
protocols like mailto: or, simply a link to a route in the same url.

# How to test
- Open a mobilization to edit
- In a content widget, link some text
- Enter in the URL input some href like: **mailto:contato@nossas.org** or **/#block-666**