### PR TITLE
Feature add react countup to widgets count

### DIFF
--- a/client/mobilizations/widgets/__plugins__/form/components/__form__.js
+++ b/client/mobilizations/widgets/__plugins__/form/components/__form__.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { browserHistory } from 'react-router'
+import CountUp from 'react-countup'
 import $ from 'jquery'
 import classnames from 'classnames'
 
@@ -103,7 +104,8 @@ class Form extends Component {
           canMoveUp={index !== 0}
           canMoveDown={index !== fields.length - 1}
           initializeEditing={this.props.hasNewField && index === fields.length - 1}
-          field={field} />
+          field={field}
+        />
       )
     })
   }
@@ -130,13 +132,23 @@ class Form extends Component {
   }
 
   renderCount () {
-    const { configurable, widget, mobilization: { body_font: bodyFont } } = this.props
+    const { configurable } = this.props
     if (!configurable) {
+      const {
+        block: { scrollTopReached: startCounting },
+        widget: { settings, form_entries_count: count },
+        mobilization: { body_font: bodyFont }
+      } = this.props
+
       return (
         <div className='mt2 h3 center white' style={{ fontFamily: bodyFont }}>
-          {widget.form_entries_count}
+          <CountUp
+            start={0}
+            end={!isNaN(count) && startCounting ? Number(count) : 0}
+            duration={5}
+          />
           &nbsp;
-          {widget.settings && widget.settings.count_text ? widget.settings.count_text : 'assinaturas'}
+          {settings && settings.count_text ? settings.count_text : 'assinaturas'}
         </div>
       )
     }

--- a/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
@@ -130,6 +130,7 @@ export class Pressure extends Component {
                   value={widget.count || 0}
                   color={mainColor}
                   text={countText}
+                  startCounting={block.scrollTopReached}
                 />
               )}
             </PressureForm>

--- a/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
@@ -70,6 +70,7 @@ export class Pressure extends Component {
 
   render () {
     const {
+      block,
       widget,
       editable,
       saving,

--- a/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.spec.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.spec.js
@@ -10,7 +10,8 @@ describe('client/mobilizations/widgets/__plugins__/pressure/components/__pressur
     editable: false,
     mobilization: { id: 1 },
     widget: { id: 1, settings: {} },
-    filledPressureWidgets: []
+    filledPressureWidgets: [],
+    block: { scrollTopReached: false }
   }
 
   beforeEach(() => {

--- a/client/mobilizations/widgets/__plugins__/pressure/components/pressure-count.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/pressure-count.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import CountUp from 'react-countup'
 
-const PressureCount = ({ value, color, text }) => {
+const PressureCount = ({ value, color, text, startCounting }) => {
   /* TODO: support all browser
    * -webkit-box-shadow: inset 0px 15px 18px -10px rgba(227,224,227,1);
    * -moz-box-shadow: inset 0px 15px 18px -10px rgba(227,224,227,1);
@@ -13,7 +14,13 @@ const PressureCount = ({ value, color, text }) => {
   return (
     <div className='pressure-count p3 bg-white rounded-bottom' style={pressureCount}>
       <p className='center m0'>
-        <span className='h1' style={{color: color}}>{value}</span>
+        <div className='h1' style={{ color }}>
+          <CountUp
+            start={0}
+            end={!isNaN(value) && startCounting ? Number(value) : 0}
+            duration={5}
+          />
+        </div>
         <span className='black bold h3 ml1'>{text}</span>
       </p>
     </div>

--- a/client/mobilizations/widgets/__plugins__/pressure/components/pressure-count.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/pressure-count.js
@@ -30,12 +30,14 @@ const PressureCount = ({ value, color, text, startCounting }) => {
 PressureCount.propTypes = {
   value: PropTypes.number,
   color: PropTypes.string,
-  text: PropTypes.string
+  text: PropTypes.string,
+  startCounting: PropTypes.bool
 }
 
 PressureCount.defaultProps = {
   value: 0,
-  text: 'pressões feitas'
+  text: 'pressões feitas',
+  startCounting: false
 }
 
 export default PressureCount

--- a/client/mobilizations/widgets/__plugins__/pressure/components/pressure-count.spec.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/pressure-count.spec.js
@@ -18,14 +18,21 @@ describe('client/mobilizations/widgets/__plugins__/pressure/components/pressure-
 
   it('should paint number with color', () => {
     wrapper.setProps({ color: '#444' })
-    const totalSpan = wrapper.find('span').at(0)
+    const totalSpan = wrapper.find('.h1').at(0)
     expect(totalSpan.props().style.color).to.equal('#444')
   })
 
-  it('should render total according value passed', () => {
+  it('should render CountUp with `end` prop init with 0 if counting not started', () => {
     wrapper.setProps({ value: 420 })
-    const totalSpan = wrapper.find('span').at(0)
-    expect(totalSpan.text()).to.equal('420')
+    const totalSpan = wrapper.find('CountUp').at(0)
+    expect(totalSpan.props().end).to.equal(0)
+  })
+
+  it('should render CountUp with `end` prop with passed value if counting already started', () => {
+    const value = 420
+    wrapper.setProps({ startCounting: true, value })
+    const totalSpan = wrapper.find('CountUp').at(0)
+    expect(totalSpan.props().end).to.equal(value)
   })
 
   it('should render text default pressões feitas', () => {

--- a/client/mobrender/components/block.js
+++ b/client/mobrender/components/block.js
@@ -43,7 +43,12 @@ const Block = ({ block, widgets, editable, hasMouseOver, onMouseOver, onMouseOut
       {editing === `${EDIT_KEY}-${block.id}` ? <BlockChangeBackground block={block} /> : null}
       <div className='clearfix widgets' style={{ padding: '5em 0' }}>
         {widgets && widgets.map(widget => (
-          <Widget key={`widget-${widget.id}`} widget={widget} editable={editable} />
+          <Widget
+            key={`widget-${widget.id}`}
+            widget={widget}
+            block={block}
+            editable={editable}
+          />
         ))}
       </div>
       {block.hidden && (

--- a/client/mobrender/components/mobilization.js
+++ b/client/mobrender/components/mobilization.js
@@ -59,7 +59,6 @@ class Mobilization extends React.Component {
 
           if (scrollPassed && !block.scrollTopReached) {
             this.updateBlock(block, { scrollTopReached: true })
-            console.log(block.id, 'was reached')
           }
         })
 
@@ -72,10 +71,8 @@ class Mobilization extends React.Component {
         const isBottom = viewportBottom >= blocksTotalHeight
         const lastBlock = this.state.blocks.slice(-1)[0]
 
-        console.log('lastBlock', lastBlock.scrollTopReached)
         if (isBottom && !lastBlock.scrollTopReached) {
           this.updateBlock( lastBlock, { scrollTopReached: true })
-          console.log('the bottom was reached')
         }
       }
     }

--- a/client/mobrender/components/mobilization.js
+++ b/client/mobrender/components/mobilization.js
@@ -55,7 +55,7 @@ class Mobilization extends React.Component {
         // than one of the blocks offsetTop
         //
         this.state.blocks.map(block => {
-          const scrollPassed = target.scrollTop >= block.offsetTop
+          const scrollPassed = (target.scrollTop + 120) >= block.offsetTop
 
           if (scrollPassed && !block.scrollTopReached) {
             this.updateBlock(block, { scrollTopReached: true })

--- a/client/mobrender/components/mobilization.spec.js
+++ b/client/mobrender/components/mobilization.spec.js
@@ -51,31 +51,35 @@ describe('client/mobrender/components/mobilization', () => {
   })
 
   it('should pass widgets filter by block to block component', () => {
+    // jump the scroll offset handling
+    wrapper.setState({ blocks: props.blocks })
+
     let expected = props.widgets.filter(w => w.block_id === props.blocks[0].id)
     expect(wrapper.find(Block).at(0).props().widgets).to.deep.equal(expected)
 
     expected = props.widgets.filter(w => w.block_id === props.blocks[1].id)
-    expect(wrapper.find(Block).at(1).props().widgets).to.deep.equal()
+    expect(wrapper.find(Block).at(1).props().widgets).to.deep.equal(expected)
   })
 
   describe('when is editable', () => {
-    beforeEach(() => {
-      wrapper.setProps({ editable: true })
-    })
+    const editableWrapper = shallow(
+      <Mobilization {...props} editable={true} />
+    )
 
     it('should renders relative layout classNames', () => {
       const layoutClassName = '.flex-auto.relative'
-      const main = wrapper.find(`div${layoutClassName}`)
+      const main = editableWrapper.find(`div${layoutClassName}`)
       expect(main.length).to.equal(1)
       expect(main.props().style).to.equal(undefined)
     })
 
     it('should not render DocumentMeta', () => {
-      expect(wrapper.find('DocumentMeta').length).to.equal(0)
+      expect(editableWrapper.find('DocumentMeta').length).to.equal(0)
     })
 
     it('should render all blocks', () => {
-      expect(wrapper.find(Block).length).to.equal(props.blocks.length)
+      editableWrapper.setProps({ editable: true })
+      expect(editableWrapper.find(Block).length).to.equal(props.blocks.length)
     })
   })
 

--- a/client/mobrender/components/widget.js
+++ b/client/mobrender/components/widget.js
@@ -7,7 +7,7 @@ import WidgetOverlay from './widget-overlay.connected'
 
 import widgets from '../widgets/config'
 
-const Widget = ({ saving, mobilization, widget, update, editable }) => {
+const Widget = ({ saving, mobilization, block, widget, update, editable }) => {
   // Resize column widget
   const { sm_size: smSize, md_size: mdSize, lg_size: lgSize } = widget
   const className = classnames(
@@ -18,7 +18,12 @@ const Widget = ({ saving, mobilization, widget, update, editable }) => {
   const widgetConfig = widgets(mobilization, widget).filter(w => w.kind === widget.kind)[0]
   const { component: Component, redirect } = widgetConfig
 
-  const widgetComponent = <Component {...{ mobilization, widget, update, editable }} />
+  const widgetComponent = (
+    <Component
+      {...{ mobilization, block, widget, update, editable }}
+    />
+  )
+
   return (
     <div className={className}>
       {saving && <Loading />}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-color": "^2.11.1",
     "react-colors-picker": "^2.3.1",
     "react-cookie": "^1.0.4",
+    "react-countup": "^2.1.1",
     "react-dom": "^15.4.2",
     "react-ga": "^2.1.2",
     "react-helmet": "^3.1.0",

--- a/routes/public/custom-domain/page.connected.js
+++ b/routes/public/custom-domain/page.connected.js
@@ -31,4 +31,13 @@ const mapStateToProps = (state, props) => ({
   protocol: state.sourceRequest.protocol
 })
 
-export default provideHooks(redial)(connect(mapStateToProps)(Page))
+const mapDispatchToProps = {
+  asyncFilterWidget: MobActions.asyncFilterWidget
+}
+
+export default provideHooks(redial)(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(Page)
+)

--- a/routes/public/custom-domain/page.js
+++ b/routes/public/custom-domain/page.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import ReactGA from 'react-ga'
 import Helmet from 'react-helmet'
 
+import DefaultServerConfig from '~server/config'
 import * as arrayUtil from '~client/utils/array'
 import { TechnicalIssues } from '~client/components/error'
 import { GoogleFontsLoader } from '~client/components/fonts'
@@ -33,6 +34,17 @@ class CustomDomainPage extends Component {
         const propagateScroll = target => { target.scrollTop = window.scrollPosition }
         blocksList && propagateScroll(blocksList)
       }
+
+      //
+      // nossas/bonde-cache widgets counter fix
+      //
+      // eslint-disable-next-line
+      const { host, asyncFilterWidget, dispatch } = this.props
+      const regex = host.match(`(.+)\.${DefaultServerConfig.appDomain}`)
+      const where = regex
+        ? { slug: regex[1].replace(/^www\./, '') }
+        : { custom_domain: host }
+      asyncFilterWidget(where)
     }
 
     const isTest = process.env.NODE_ENV === undefined || process.env.NODE_ENV === 'test'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,6 +2304,10 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
+countup.js@^1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/countup.js/-/countup.js-1.8.5.tgz#0941f62c605835c601478b45e8c096b16d7e9881"
+
 cpf_cnpj@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/cpf_cnpj/-/cpf_cnpj-0.2.0.tgz#a032c19242a38e8363edce4e78bb1fbe9d664aa5"
@@ -6604,6 +6608,12 @@ react-cookie@^1.0.4:
   dependencies:
     cookie "^0.3.1"
     object-assign "^4.1.0"
+
+react-countup@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-countup/-/react-countup-2.1.1.tgz#0fccacfd6d2d9045d347d07e4c0e18b1c1fcd33f"
+  dependencies:
+    countup.js "^1.8.5"
 
 react-dock@^0.2.1:
   version "0.2.3"


### PR DESCRIPTION
# Related issues
- Add async count load from pressure and form_entries widget #637

# How to test

### Widgets counter fix
- The widgets count async refetch is only testable on [nossas/bonde-cache](github.com/nossas/bonde-cache) environment. Unfortunately, this test only be able in production 😞 

### Counter animation w/ [react-countup](https://github.com/glennreyes/react-countup)
- Open a mobilization that contains a form widget, pressure widget or both
- Scroll the page
- When the page's `offsetTop` reached the block's `offsetTop - 120px`, the counter should be initiated.