### PR TITLE
Change field name for custom default email

### DIFF
--- a/routes/admin/authenticated/sidebar/community-settings/info/page.connected.js
+++ b/routes/admin/authenticated/sidebar/community-settings/info/page.connected.js
@@ -18,10 +18,10 @@ const mapStateToProps = state => {
 const mapDispatchToProps = { submit: asyncEdit }
 
 const fields = [
-  'id', 'image', 'name', 'city', 'description', 'custom_from_email'
+  'id', 'image', 'name', 'city', 'description', 'email_template_from'
 ]
 
-const validate = ({ name, city, custom_from_email: customFromEmail }) => {
+const validate = ({ name, city, email_template_from: customFromEmail }) => {
   const errors = {}
 
   if (!name) {
@@ -31,7 +31,7 @@ const validate = ({ name, city, custom_from_email: customFromEmail }) => {
     errors.city = 'Informe em qual cidade sua comunidade atua'
   }
   if (customFromEmail && !isValidFromEmail(customFromEmail)) {
-    errors.custom_from_email = 'E-mail de resposta fora do formato padrão'
+    errors.email_template_from = 'E-mail de resposta fora do formato padrão'
   }
   return errors
 }

--- a/routes/admin/authenticated/sidebar/community-settings/info/page.js
+++ b/routes/admin/authenticated/sidebar/community-settings/info/page.js
@@ -12,7 +12,7 @@ import { SettingsForm } from '~client/ux/components'
 
 const CommunitySettingsInfoPage = ({
   fields: {
-    image, name, city, description, custom_from_email: customFromEmail
+    image, name, city, description, email_template_from: customFromEmail
   },
   location,
   community,
@@ -29,7 +29,7 @@ const CommunitySettingsInfoPage = ({
     </FormGroup>
     <FormGroup controlId='descriptionId' {...description}>
       <ControlLabel>Descrição</ControlLabel>
-      <FormControl componentusClass='textarea' />
+      <FormControl componentClass='textarea' />
     </FormGroup>
     <FormGroup controlId='cityId' {...city}>
       <ControlLabel>Cidade</ControlLabel>
@@ -51,7 +51,8 @@ CommunitySettingsInfoPage.propTypes = {
     image: PropTypes.object.isRequired,
     name: PropTypes.object.isRequired,
     city: PropTypes.object.isRequired,
-    description: PropTypes.object.isRequired
+    description: PropTypes.object.isRequired,
+    email_template_from: PropTypes.object
   }),
   community: PropTypes.object.isRequired
 }


### PR DESCRIPTION
## How to test

1. In `/community/info` page, add or change a value for `E-MAIL DE RESPOSTA PARA NOTIFICAÇÕES` field
2. For check the successifully, update your browser with `SHIFT`+`F5`, the field should keep updated

## Issues:

- Community default e-mail was not saved after changes. Closes #639