### PR TITLE
Feature add sharing image fb specification

### DIFF
--- a/client/mobilizations/components/form-share.js
+++ b/client/mobilizations/components/form-share.js
@@ -20,9 +20,21 @@ const FormShare = ({
       <i className='fa fa-facebook-square align-middle' style={{ color: '#3b5998' }} />
       <span className='align-middle pl2'>Share de Facebook</span>
     </div>
-    <p className='mb2 lightgray'>
+    <p className='mb1 lightgray'>
       Configure o post que será publicado no Facebook sempre que alguém compartilhar a ação.
       É importante que esses textos sejam cativantes e curtos para não aparecerem cortados. :)
+    </p>
+    <p className='mb3 lightgray'>
+      Use imagens com pelo menos 1200x630 pixels para a melhor exibição em dispositivos de
+      alta resolução. No mínimo, você deve usar imagens que tenham 600x315 pixels para exibir
+      publicações na página com link com imagens maiores. O tamanho máximo das imagens é de 8 MB.
+      &nbsp;
+      <a
+        href='https://developers.facebook.com/docs/sharing/best-practices#images'
+        target='_blank'
+      >
+        Saiba mais <i className='fa fa-external-link' style={{ fontSize: 12 }} />
+      </a>.
     </p>
 
     <div className='clearfix col-12'>

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -661,6 +661,8 @@ export default {
   //   - /mobilizations/:mobilization_id/sharing
   'mobilizations.components--form-share.facebook.title': 'Share de Facebook',
   'mobilizations.components--form-share.facebook.helper-text': 'Configure o post que será publicado no Facebook sempre que alguém compartilhar a ação. É importante que esses textos sejam cativantes e curtos para não aparecerem cortados. :)',
+  'mobilizations.components--form-share.facebook.fb.image.helper-text': 'Use imagens com pelo menos 1200x630 pixels para a melhor exibição em dispositivos de alta resolução. No mínimo, você deve usar imagens que tenham 600x315 pixels para exibir publicações na página com link com imagens maiores. O tamanho máximo das imagens é de 8 MB.',
+  'mobilizations.components--form-share.facebook.fb.image.link': 'Saiba mais',
   'mobilizations.components--form-share.facebook.form.share-image.label': 'Imagem',
   'mobilizations.components--form-share.facebook.form.share-title.label': 'Título do post',
   'mobilizations.components--form-share.facebook.form.share-title.placeholder': 'Um título direto que passe a ideia da sua mobilização',


### PR DESCRIPTION
# Related issues
- Add more info about dimensions from facebook best practices #619

# How to test
It should have a text that describes the facebook image dimensions specification

### Mobilization's sharing settings
- Access the route `/mobilizations/:mobilization_id/sharing`
- The page should contain the text like screenshot below:
<img width="1187" alt="screen shot 2017-06-06 at 17 39 24" src="https://user-images.githubusercontent.com/5435389/26850831-4b67b1ba-4adf-11e7-9e88-70f9f4c133d9.png">

### Mobilization's launch, step 02
- Access the route `/mobilizations/:mobilization_id/launch`
- The page should contain the text like screenshot below:
<img width="516" alt="screen shot 2017-06-06 at 17 39 12" src="https://user-images.githubusercontent.com/5435389/26850864-607a11e2-4adf-11e7-8fe4-66b419170098.png">
