### PR TITLE
Hotfix redirect after create a new mobilization

### DIFF
--- a/intl/locale-data/en.js
+++ b/intl/locale-data/en.js
@@ -29,5 +29,5 @@ export default {
   'notify.community.check--dns--failure': 'The sync is still pending, you can try again in a few minutes.',
 
   'notification--slug-updated-message.title': 'Important',
-  'notification--slug-updated-message.message': 'The slug of his mobilization was changed. If you do some DNS redirection via CNAME, be sure to update it.',
+  'notification--slug-updated-message.message': 'The slug of this mobilization was changed. If you do some DNS redirection via CNAME, be sure to update it.',
 }

--- a/routes/admin/authenticated/sidebar/mobilizations-new/page.connected.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-new/page.connected.js
@@ -7,11 +7,14 @@ import { asyncAddMobilization } from '~client/mobrender/redux/action-creators'
 
 import Page from './page'
 
+const form = 'newMobilizationForm'
+
 const mapStateToProps = (state, props) => {
   const mobilization = MobSelectors(state, props).getMobilization() || {}
   const community = CommunitySelectors.getCurrent(state)
   return {
     mobilization,
+    formName: form,
     initialValues: {
       ...mobilization,
       community_id: mobilization.community_id || community.id
@@ -24,7 +27,7 @@ const mapActionCreatorsToProps = {
 }
 
 export default reduxForm(
-  { form: 'newMobilizationForm', fields, validate },
+  { form, fields, validate },
   mapStateToProps,
   mapActionCreatorsToProps
 )(Page)

--- a/routes/admin/authenticated/sidebar/mobilizations-new/page.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-new/page.js
@@ -12,8 +12,7 @@ const MobilizationsNewPage = props => (
       <h2 className='h1 mt0 mb3 center'>Qual o objetivo da sua mobilização?</h2>
       <MobilizationBasicsForm
         className='bg-white'
-        onFinishSubmit={() => {
-          const { mobilization } = props
+        onFinishSubmit={mobilization => {
           mobilization && browserHistory.push(
             paths.mobilizationTemplatesChoose(mobilization)
           )

--- a/routes/admin/authenticated/sidebar/mobilizations-settings-basics/page.connected.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-settings-basics/page.connected.js
@@ -23,6 +23,7 @@ const redial = {
 const mapStateToProps = state => {
   const mobilization = MobSelectors(state).getMobilization()
   return {
+    formName: form,
     initialValues: mobilization,
     mobilization
   }
@@ -32,12 +33,10 @@ const mapActionCreatorsToProps = {
   submit: MobActions.asyncUpdateMobilization
 }
 
+const form = 'mobilizationBasicsForm'
+
 export default provideHooks(redial)(
   connect(mapStateToProps, mapActionCreatorsToProps)(
-    reduxForm({
-      form: 'mobilizationBasicsForm',
-      fields: [...fields, 'id'],
-      validate
-    })(Page)
+    reduxForm({ form, fields: [...fields, 'id'], validate })(Page)
   )
 )


### PR DESCRIPTION
# Related issues
- Continue button doesn't redirect to the second step #662

# How to test
Test cases

### Create a new mobilization
- Access the page to create a new mobilization (route: `/mobilizations/new`)
- Try to create a new mobilization with a slug that already have been taken (e.g. **hello-world**)
- It should display a validation error in the **SLUG** input's label:
<img width="773" alt="screen shot 2017-06-13 at 23 43 17" src="https://user-images.githubusercontent.com/5435389/27113239-1f69bb90-5092-11e7-8a29-8227aed70901.png">

- Choose a valid slug and, make sure that on the new mobilization form page, the dns warning notification should not be displayed

### Edit an existing mobilization's slug
- Open an mobilization to edit and, go to the basic info page to edit
(route: `/mobilizations/:mobilization_id/basics`)
- Try to change the **SLUG** field value to an existing (e.g. **hello-world**)
- It should display a validation error in the **SLUG** input's label:

![image](https://user-images.githubusercontent.com/5435389/27113494-7ae3bb6e-5093-11e7-9bc9-2ad996891a22.png)

- Entry a valid slug (different from initially registered e.g. **hello-world-20170613235556)**
- It should display the dns notification after save.