### PR TITLE
Feature remove some items from community sidebar

### DIFF
--- a/client/community/components/settings-menu.js
+++ b/client/community/components/settings-menu.js
@@ -23,7 +23,7 @@ const SettingsMenu = ({ location: { pathname } }) => {
         <Tab text='Membros' path={invitePath} isActive={invitePath === pathname} />
         <Tab text='Mailchimp' path={mailchimpPath} isActive={mailchimpPath === pathname} />
         <Tab text='Recebedor' path={recipientPath} isActive={recipientPath === pathname} />
-        <Tab text='Relatório' path={reportPath} isActive={reportPath === pathname} />
+        <Tab text='Métricas' path={reportPath} isActive={reportPath === pathname} />
         <Tab text='Domínios' path={paths.communityDomain()} isActive={domainPageIsActive} />
       </Tabs>
     </SettingsPageMenuLayout>

--- a/client/components/navigation/sidebar/sidebar.js
+++ b/client/components/navigation/sidebar/sidebar.js
@@ -12,33 +12,18 @@ const Sidebar = ({ children, loading, mobilization, user, community }) => loadin
       {!mobilization ? (
         <SidenavList className='bg-lighten-2'>
           <SidenavListItem
-            text='Minhas Mobilizações'
+            text='Mobilizações'
             icon='list'
             href={paths.mobilizations()}
           />
           <SidenavListItem
-            text='Informações'
+            text='Comunidade'
             icon='info-circle'
             href={paths.communityInfo()}
           />
           <SidenavListItem
-            text='Membros'
-            icon='users'
-            href={paths.communityInvite()}
-          />
-          <SidenavListItem
-            text='Mailchimp'
-            icon='envelope-o'
-            href={paths.communityMailchimp()}
-          />
-          <SidenavListItem
-            text='Recebedor'
-            icon='money'
-            href={paths.communityRecipient()}
-          />
-          <SidenavListItem
-            text='Relatório'
-            icon='file-excel-o'
+            text='Métricas'
+            icon='line-chart'
             href={paths.communityReport()}
           />
           <SidenavListItem

--- a/client/components/navigation/sidebar/sidebar.spec.js
+++ b/client/components/navigation/sidebar/sidebar.spec.js
@@ -127,11 +127,11 @@ describe('client/components/navigation/sidebar/sidebar', () => {
       })
 
       describe('community settings navbar items', () => {
-        describe('- minhas mobilizações', () => {
+        describe('- mobilizações', () => {
           beforeAll(incrementIndex)
 
           it('should render with its text properly', () => {
-            const text = 'Minhas Mobilizações'
+            const text = 'Mobilizações'
             expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
           })
           it('should render with its icon properly', () => {
@@ -144,11 +144,11 @@ describe('client/components/navigation/sidebar/sidebar', () => {
           })
         })
 
-        describe('- informações', () => {
+        describe('- comunidade', () => {
           beforeAll(incrementIndex)
 
           it('should render with its text properly', () => {
-            const text = 'Informações'
+            const text = 'Comunidade'
             expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
           })
           it('should render with its icon properly', () => {
@@ -161,70 +161,36 @@ describe('client/components/navigation/sidebar/sidebar', () => {
           })
         })
 
-        describe('- membros', () => {
+        describe('- métricas', () => {
           beforeAll(incrementIndex)
 
           it('should render with its text properly', () => {
-            const text = 'Membros'
+            const text = 'Métricas'
             expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
           })
           it('should render with its icon properly', () => {
-            const icon = 'users'
-            expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
-          })
-          it('should render with its href properly', () => {
-            const href = paths.communityInvite()
-            expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
-          })
-        })
-
-        describe('- mailchimp', () => {
-          beforeAll(incrementIndex)
-
-          it('should render with its text properly', () => {
-            const text = 'Mailchimp'
-            expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
-          })
-          it('should render with its icon properly', () => {
-            const icon = 'envelope-o'
-            expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
-          })
-          it('should render with its href properly', () => {
-            const href = paths.communityMailchimp()
-            expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
-          })
-        })
-
-        describe('- recebedor', () => {
-          beforeAll(incrementIndex)
-
-          it('should render with its text properly', () => {
-            const text = 'Recebedor'
-            expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
-          })
-          it('should render with its icon properly', () => {
-            const icon = 'money'
-            expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
-          })
-          it('should render with its href properly', () => {
-            const href = paths.communityRecipient()
-            expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
-          })
-        })
-
-        describe('- relatório', () => {
-          beforeAll(incrementIndex)
-
-          it('should render with its text properly', () => {
-            const text = 'Relatório'
-            expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
-          })
-          it('should render with its icon properly', () => {
-            const icon = 'file-excel-o'
+            const icon = 'line-chart'
             expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
           })
           it('should render with its href properly', () => {
             const href = paths.communityReport()
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
+          })
+        })
+
+        describe('- domínios', () => {
+          beforeAll(incrementIndex)
+
+          it('should render with its text properly', () => {
+            const text = 'Domínios'
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().text).to.be.equal(text)
+          })
+          it('should render with its icon properly', () => {
+            const icon = 'cogs'
+            expect(wrapper.find('SidenavListItem').at(itemIndex).props().icon).to.be.equal(icon)
+          })
+          it('should render with its href properly', () => {
+            const href = paths.communityDomain()
             expect(wrapper.find('SidenavListItem').at(itemIndex).props().href).to.be.equal(href)
           })
         })

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -139,7 +139,7 @@ export default {
   'community.components--settings-menu.tabs.info': 'Informações',
   'community.components--settings-menu.tabs.mailchimp': 'Mailchimp',
   'community.components--settings-menu.tabs.recipient': 'Recebedor',
-  'community.components--settings-menu.tabs.report': 'Relatório',
+  'community.components--settings-menu.tabs.metrics': 'Métricas',
   'community.components--settings-menu.tabs.domains': 'Domínios',
 
   // component community domain preview
@@ -372,11 +372,9 @@ export default {
   //   - /mobilizations/:mobilization_id/widgets/:widget_id/pressure/finish
   //   - /mobilizations/new
   //   - /mobilizations/templates/list
-  'components.navigation--sidebar.community-settings.item.mobilizations': 'Minhas Mobilizações',
-  'components.navigation--sidebar.community-settings.item.info': 'Informações',
-  'components.navigation--sidebar.community-settings.item.mailchimp': 'Mailchimp',
-  'components.navigation--sidebar.community-settings.item.recipient': 'Recebedor',
-  'components.navigation--sidebar.community-settings.item.report': 'Relatório',
+  'components.navigation--sidebar.community-settings.item.mobilizations': 'Mobilizações',
+  'components.navigation--sidebar.community-settings.item.info': 'Comunidade',
+  'components.navigation--sidebar.community-settings.item.metrics': 'Métricas',
   'components.navigation--sidebar.community-settings.item.domains': 'Domínios',
 
   'components.navigation--sidebar.mobilization-settings.item.launch': 'PUBLICAR BONDE',


### PR DESCRIPTION
# Related issues
- Remove links from sidebar #676

# How to test
- Log into BONDE
- Choose a community on the community list page
- Hover on sidebar on the left of the page
- Some items should be removed as you can see on the screenshot comparison below:

| before                                                                                                                                                               | expected                                                                                                                                                             |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="281" alt="screen shot 2017-06-19 at 15 19 03" src="https://user-images.githubusercontent.com/5435389/27300246-7141974a-5505-11e7-8abc-ba0cfe549172.png"> | <img width="281" alt="screen shot 2017-06-19 at 15 38 51" src="https://user-images.githubusercontent.com/5435389/27300247-714218f0-5505-11e7-8e8a-72b3515ce465.png"> |