### PR TITLE
Feature community members settings changes

### DIFF
--- a/client/community/components/settings-menu.js
+++ b/client/community/components/settings-menu.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
 import { Tabs, Tab } from '~client/components/navigation'
 import { SettingsPageMenuLayout } from '~client/components/layout'
 
@@ -17,14 +18,75 @@ const SettingsMenu = ({ location: { pathname } }) => {
   const domainPageIsActive = domainPaths.indexOf(pathname) !== -1
 
   return (
-    <SettingsPageMenuLayout title='Configurações da comunidade'>
+    <SettingsPageMenuLayout
+      title={
+        <FormattedMessage
+          id='community.components--settings-menu.title'
+          defaultMessage='Configurações da comunidade'
+        />
+      }
+    >
       <Tabs>
-        <Tab text='Informações' path={infoPath} isActive={infoPath === pathname} />
-        <Tab text='Membros' path={invitePath} isActive={invitePath === pathname} />
-        <Tab text='Mailchimp' path={mailchimpPath} isActive={mailchimpPath === pathname} />
-        <Tab text='Recebedor' path={recipientPath} isActive={recipientPath === pathname} />
-        <Tab text='Métricas' path={reportPath} isActive={reportPath === pathname} />
-        <Tab text='Domínios' path={paths.communityDomain()} isActive={domainPageIsActive} />
+        <Tab
+          isActive={infoPath === pathname}
+          path={infoPath}
+          text={
+            <FormattedMessage
+              id='community.components--settings-menu.tabs.info'
+              defaultMessage='Informações'
+            />
+          }
+        />
+        <Tab
+          isActive={invitePath === pathname}
+          path={invitePath}
+          text={
+            <FormattedMessage
+              id='community.components--settings-menu.tabs.mobilizers'
+              defaultMessage='Mobilizadores'
+            />
+          }
+        />
+        <Tab
+          isActive={mailchimpPath === pathname}
+          path={mailchimpPath}
+          text={
+            <FormattedMessage
+              id='community.components--settings-menu.tabs.mailchimp'
+              defaultMessage='Mailchimp'
+            />
+          }
+        />
+        <Tab
+          isActive={recipientPath === pathname}
+          path={recipientPath}
+          text={
+            <FormattedMessage
+              id='community.components--settings-menu.tabs.recipient'
+              defaultMessage='Recebedor'
+            />
+          }
+        />
+        <Tab
+          isActive={reportPath === pathname}
+          path={reportPath}
+          text={
+            <FormattedMessage
+              id='community.components--settings-menu.tabs.metrics'
+              defaultMessage='Métricas'
+            />
+          }
+        />
+        <Tab
+          isActive={domainPageIsActive}
+          path={paths.communityDomain()}
+          text={
+            <FormattedMessage
+              id='community.components--settings-menu.tabs.domains'
+              defaultMessage='Domínios'
+            />
+          }
+        />
       </Tabs>
     </SettingsPageMenuLayout>
   )

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -236,6 +236,9 @@ export default {
   // filepath: /routes/admin/authenticated/sidebar/community-settings/invite/page.js
   // routepath: /community/invite
   'page--community-invite.helper-text': 'Ao preencher o campo abaixo, você estará convidando novos mobilizadores para compor sua comunidade.',
+  'page--community-invite.form.email.label': 'Email',
+  'page--community-invite.form.email.placeholder': 'Insira um email para convidar. Ex: mobilizador@email.com',
+  'page--community-invite.form.submit-button.default': 'Convidar',
 
   // component settings form
   // filepath: /client/ux/components/settings-form/index.js

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -137,6 +137,7 @@ export default {
   //   - /community/report
   'community.components--settings-menu.title': 'Configurações da comunidade',
   'community.components--settings-menu.tabs.info': 'Informações',
+  'community.components--settings-menu.tabs.mobilizers': 'Mobilizadores',
   'community.components--settings-menu.tabs.mailchimp': 'Mailchimp',
   'community.components--settings-menu.tabs.recipient': 'Recebedor',
   'community.components--settings-menu.tabs.metrics': 'Métricas',

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -232,6 +232,11 @@ export default {
   'page--community-info.form.custom-from-email.helper-text': 'Você deve preencher seguindo o formato padrão: Nome do contato <contato@provedor.com>',
   'page--community-info.form.custom-from-email.validation.invalid-email-format': 'E-mail de resposta fora do formato padrão',
 
+  // page community invite
+  // filepath: /routes/admin/authenticated/sidebar/community-settings/invite/page.js
+  // routepath: /community/invite
+  'page--community-invite.helper-text': 'Ao preencher o campo abaixo, você estará convidando novos mobilizadores para compor sua comunidade.',
+
   // component settings form
   // filepath: /client/ux/components/settings-form/index.js
   // routepath:

--- a/routes/admin/authenticated/sidebar/community-settings/invite/page.connected.js
+++ b/routes/admin/authenticated/sidebar/community-settings/invite/page.connected.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
 import { reduxForm } from 'redux-form'
+import { injectIntl } from 'react-intl'
 
 import { asyncInvite } from '~client/community/action-creators'
 import * as CommunitySelectors from '~client/community/selectors'
@@ -29,5 +30,5 @@ const validate = ({ email }) => {
 }
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(
-  reduxForm({ form: 'communityInviteForm', fields, validate })(Page)
+  reduxForm({ form: 'communityInviteForm', fields, validate })(injectIntl(Page))
 )

--- a/routes/admin/authenticated/sidebar/community-settings/invite/page.js
+++ b/routes/admin/authenticated/sidebar/community-settings/invite/page.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, intlShape } from 'react-intl'
 
 import {
   FormRedux,
@@ -22,6 +22,7 @@ const CommunitySettingsInfoPage = ({
   location,
   community,
   downloadActivists,
+  intl,
   ...formProps
 }) => (
   <FormRedux
@@ -33,21 +34,34 @@ const CommunitySettingsInfoPage = ({
       <FormattedMessage
         id='page--community-invite.helper-text'
         defaultMessage={
-          'Ao preencher o campo abaixo, você estará convidando novos mobilizadores para compor' +
+          'Ao preencher o campo abaixo, você estará convidando novos mobilizadores para compor ' +
           'sua comunidade.'
         }
       />
     </Info>
 
     <FormGroup controlId='email' {...email}>
-      <ControlLabel>Pessoas</ControlLabel>
+      <ControlLabel>
+        <FormattedMessage
+          id='page--community-invite.form.email.label'
+          defaultMessage='Email'
+        />
+      </ControlLabel>
       <FormControl
         type='text'
-        placeholder='Insira um email para convidar'
+        placeholder={intl.formatMessage({
+          id: 'page--community-invite.form.email.placeholder',
+          defaultMessage: 'Insira um email para convidar. Ex: mobilizador@email.com'
+        })}
         containerClassName={styles.inlineFormControlContainer}
         content={(
           <span className={styles.buttonWrapper}>
-            <Button type='submit'>Convidar</Button>
+            <Button type='submit'>
+              <FormattedMessage
+                id='page--community-invite.form.submit-button.default'
+                defaultMessage='Convidar'
+              />
+            </Button>
           </span>
         )}
       />
@@ -63,7 +77,8 @@ CommunitySettingsInfoPage.propTypes = {
     description: PropTypes.object.isRequired,
     email_template_from: PropTypes.object
   }),
-  community: PropTypes.object.isRequired
+  community: PropTypes.object.isRequired,
+  intl: intlShape.isRequired
 }
 
 export default CommunitySettingsInfoPage

--- a/routes/admin/authenticated/sidebar/community-settings/invite/page.js
+++ b/routes/admin/authenticated/sidebar/community-settings/invite/page.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
 
 import {
   FormRedux,
@@ -9,6 +10,7 @@ import {
   UploadImageField,
   HelpBlock
 } from '~client/components/forms'
+import { Info } from '~client/components/notify'
 import { SettingsForm } from '~client/ux/components'
 import Button from '~client/ux/components/button'
 
@@ -27,6 +29,16 @@ const CommunitySettingsInfoPage = ({
     nosubmit
     onFinishSubmit={() => resetForm()}
   >
+    <Info title='Informação'>
+      <FormattedMessage
+        id='page--community-invite.helper-text'
+        defaultMessage={
+          'Ao preencher o campo abaixo, você estará convidando novos mobilizadores para compor' +
+          'sua comunidade.'
+        }
+      />
+    </Info>
+
     <FormGroup controlId='email' {...email}>
       <ControlLabel>Pessoas</ControlLabel>
       <FormControl

--- a/routes/admin/authenticated/sidebar/community-settings/invite/page.spec.js
+++ b/routes/admin/authenticated/sidebar/community-settings/invite/page.spec.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
-
+import { shallowWithIntl } from '~root/intl/helpers'
 import * as mock from '~client/utils/mock'
 import Page from '~routes/admin/authenticated/sidebar/community-settings/invite/page'
 
@@ -10,6 +9,6 @@ describe('routes/admin/authenticated/sidebar/community-settings/invite/page', ()
   }
 
   it('should render without crashed', () => {
-    shallow(<Page {...props} />)
+    shallowWithIntl(<Page {...props} />)
   })
 })


### PR DESCRIPTION
# Related issues
- Community members settings changes #673

# How to test
- Log into BONDE
- Choose a community on the community list page
- Access the page to invite a mobilizer to your community (route `/community/invite`)
- Some changes should be made:
  - The settings page header tab should be changed from **Membros** to **Mobilizadores**
  - A helper text should be placed on top of the page content
  - The form's field label should be changed from **PESSOAS** to **EMAIL**

| before                                                                                                                                                                | expected                                                                                                                                                              |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1263" alt="screen shot 2017-06-19 at 16 44 28" src="https://user-images.githubusercontent.com/5435389/27302874-2ba6bf12-550f-11e7-95b7-02bd6edec9da.png"> | <img width="1249" alt="screen shot 2017-06-19 at 16 44 37" src="https://user-images.githubusercontent.com/5435389/27302873-2ba66d46-550f-11e7-86cd-b4c32004ded5.png"> |