### PR TITLE
Feature provide an option to cancel the subscription

### DIFF
--- a/client/subscriptions/redux/action-creators/async-subscription-delete.js
+++ b/client/subscriptions/redux/action-creators/async-subscription-delete.js
@@ -1,0 +1,33 @@
+import { addNotification as notify } from 'reapop'
+import * as notifications from '~client/utils/notifications'
+import * as t from '~client/subscriptions/redux/action-types'
+import { createAction } from '~client/utils/redux'
+import * as AwaitActions from '~client/components/await/redux/action-creators'
+
+//
+// Action to cancel a subscription.
+//
+// @param Object({
+//   id: Integer|String (required)
+//   token: String (required)
+// })
+//
+export default ({ id, token }) => (dispatch, getState, { api, intl }) => {
+  const endpoint = `/subscriptions/${id}`
+  const config = { params: { token } }
+
+  dispatch(AwaitActions.setLoading(true))
+  return api
+    .delete(endpoint, config)
+    .then(({ data }) => {
+      dispatch(AwaitActions.setLoading(false))
+      dispatch(createAction(t.ASYNC_FETCH_SUCCESS, data))
+      dispatch(notify(notifications.subscriptionCancelSuccess(intl)))
+    })
+    .catch(e => {
+      dispatch(AwaitActions.setLoading(false))
+      dispatch(createAction(t.ASYNC_FETCH_FAILURE, e))
+      dispatch(notify(notifications.genericRequestError()))
+      return Promise.reject(e)
+    })
+}

--- a/client/subscriptions/redux/action-creators/index.js
+++ b/client/subscriptions/redux/action-creators/index.js
@@ -1,3 +1,4 @@
+export { default as asyncSubscriptionDelete } from './async-subscription-delete'
 export { default as asyncSubscriptionRecharge } from './async-subscription-recharge'
 export { default as asyncSubscriptionFetch } from './async-subscription-fetch'
 

--- a/client/utils/notifications.js
+++ b/client/utils/notifications.js
@@ -95,7 +95,7 @@ export const subscriptionCancelSuccess = intl => ({
   message: intl.formatMessage({
     id: 'notification--subscription-cancel-success.message',
     defaultMessage: 'Sua assinatura foi cancelada e, o valor da sua ' +
-      'doação não será debitado até que você reative-a.',
+      'doação não será debitado até que você faça uma nova doação recorrente.',
   }),
   dismissAfter: 15000,
   dismissible: true,

--- a/client/utils/notifications.js
+++ b/client/utils/notifications.js
@@ -85,3 +85,19 @@ export const communityInviteSuccess = (intl, email) => ({
   dismissible: true,
   closeButton: false
 })
+
+export const subscriptionCancelSuccess = intl => ({
+  title: intl.formatMessage({
+    id: 'notification--subscription-cancel-success.title',
+    defaultMessage: 'Assinatura cancelada'
+  }),
+  status: 'success',
+  message: intl.formatMessage({
+    id: 'notification--subscription-cancel-success.message',
+    defaultMessage: 'Sua assinatura foi cancelada e, o valor da sua ' +
+      'doação não será debitado até que você reative-a.',
+  }),
+  dismissAfter: 15000,
+  dismissible: true,
+  closeButton: false
+})

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -59,6 +59,7 @@ export default {
   'page--subscription-edit.helper-text': 'Selecione abaixo qual informação da sua doação quer alterar:',
   'page--subscription-edit.button.creditcard': 'Cartão de crédito',
   'page--subscription-edit.button.recurring': 'Data da doação',
+  'page--subscription-edit.cancel-subscription.confirm': 'Você está prestes a cancelar sua assinatura. Fazendo isso, você deixa de nos ajudar com suas doações. Tem certeza que quer continuar?',
   'page--subscription-edit.link.cancel-subscription': 'Quero cancelar a minha assinatura.',
 
   // form subscription credit card

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -59,7 +59,7 @@ export default {
   'page--subscription-edit.helper-text': 'Selecione abaixo qual informação da sua doação quer alterar:',
   'page--subscription-edit.button.creditcard': 'Cartão de crédito',
   'page--subscription-edit.button.recurring': 'Data da doação',
-  'page--subscription-edit.cancel-subscription.confirm': 'Você está prestes a cancelar sua assinatura. Fazendo isso, você deixa de nos ajudar com suas doações. Tem certeza que quer continuar?',
+  'page--subscription-edit.cancel-subscription.confirm': 'Você está prestes a cancelar sua assinatura. Tem certeza que quer continuar?',
   'page--subscription-edit.link.cancel-subscription': 'Quero cancelar a minha assinatura.',
 
   // form subscription credit card

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -119,7 +119,7 @@ export default {
   'notification--community-invite-success.message': 'O convite para {email} foi enviado com sucesso! Mais um passo foi dado pra sua comunidade crescer ainda mais (:',
 
   'notification--subscription-cancel-success.title': 'Assinatura cancelada',
-  'notification--subscription-cancel-success.message': 'Sua assinatura foi cancelada e, o valor da sua doação não será debitado até que você reative-a.',
+  'notification--subscription-cancel-success.message': 'Sua assinatura foi cancelada e, o valor da sua doação não será debitado até que você faça uma nova doação recorrente.',
 
   // community dns notifications
   // filepath: /client/community/notifications/dns.js

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -59,6 +59,7 @@ export default {
   'page--subscription-edit.helper-text': 'Selecione abaixo qual informação da sua doação quer alterar:',
   'page--subscription-edit.button.creditcard': 'Cartão de crédito',
   'page--subscription-edit.button.recurring': 'Data da doação',
+  'page--subscription-edit.link.cancel-subscription': 'Quero cancelar a minha assinatura.',
 
   // form subscription credit card
   // filepath: /client/subscriptions/forms/credit-card-form.js
@@ -115,6 +116,9 @@ export default {
 
   'notification--community-invite-success.title': 'Oba!',
   'notification--community-invite-success.message': 'O convite para {email} foi enviado com sucesso! Mais um passo foi dado pra sua comunidade crescer ainda mais (:',
+
+  'notification--subscription-cancel-success.title': 'Assinatura cancelada',
+  'notification--subscription-cancel-success.message': 'Sua assinatura foi cancelada e, o valor da sua doação não será debitado até que você reative-a.',
 
   // community dns notifications
   // filepath: /client/community/notifications/dns.js

--- a/routes/public/subscription-edit/page.connected.js
+++ b/routes/public/subscription-edit/page.connected.js
@@ -1,5 +1,6 @@
 import { provideHooks } from 'redial'
 import { connect } from 'react-redux'
+import { injectIntl } from 'react-intl'
 import {
   asyncSubscriptionDelete,
   asyncSubscriptionFetch,
@@ -36,6 +37,6 @@ const mapDispatchToProps = {
   removeAnimationStack
 }
 
-export default provideHooks(redial)(
+export default injectIntl(provideHooks(redial)(
   connect(mapStateToProps, mapDispatchToProps)(Page)
-)
+))

--- a/routes/public/subscription-edit/page.connected.js
+++ b/routes/public/subscription-edit/page.connected.js
@@ -1,12 +1,18 @@
 import { provideHooks } from 'redial'
 import { connect } from 'react-redux'
-import * as SubscriptionActions from '~client/subscriptions/redux/action-creators'
+import {
+  asyncSubscriptionDelete,
+  asyncSubscriptionFetch,
+  setModificationType,
+  appendAnimationStack,
+  removeAnimationStack
+} from '~client/subscriptions/redux/action-creators'
 import SubscriptionEditSelectors from '~client/subscriptions/redux/selectors/edit'
 import Page from './page'
 
 const redial = {
   fetch: ({ dispatch, params, query }) => {
-    return dispatch(SubscriptionActions.asyncSubscriptionFetch({
+    return dispatch(asyncSubscriptionFetch({
       id: params.id,
       token: query.token
     }))
@@ -23,7 +29,12 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = SubscriptionActions
+const mapDispatchToProps = {
+  asyncSubscriptionDelete,
+  setModificationType,
+  appendAnimationStack,
+  removeAnimationStack
+}
 
 export default provideHooks(redial)(
   connect(mapStateToProps, mapDispatchToProps)(Page)

--- a/routes/public/subscription-edit/page.js
+++ b/routes/public/subscription-edit/page.js
@@ -79,6 +79,7 @@ const SubscriptionEditPage = props => {
     url,
     modificationType,
     animationStack,
+    asyncSubscriptionDelete,
     setModificationType,
     appendAnimationStack,
     removeAnimationStack
@@ -163,6 +164,19 @@ const SubscriptionEditPage = props => {
               </div>
             ))}
           </CSSTransitionGroup>
+          <p className='link--cancel center mt3 lightgray link'>
+            <a
+              onClick={() => {
+                animationStack.length && removeAnimationStack(0)
+                asyncSubscriptionDelete(initialValues)
+              }}
+            >
+              <FormattedMessage
+                id='page--subscription-edit.link.cancel-subscription'
+                defaultMessage='Quero cancelar a minha assinatura.'
+              />
+            </a>
+          </p>
         </section>
       </Background>
     </div>

--- a/routes/public/subscription-edit/page.js
+++ b/routes/public/subscription-edit/page.js
@@ -171,7 +171,6 @@ const SubscriptionEditPage = props => {
                 const message = intl.formatMessage({
                   id: 'page--subscription-edit.cancel-subscription.confirm',
                   defaultMessage: 'Você está prestes a cancelar sua assinatura. ' +
-                    'Fazendo isso, você deixa de nos ajudar com suas doações. ' +
                     'Tem certeza que quer continuar?'
                 })
 

--- a/routes/public/subscription-edit/page.js
+++ b/routes/public/subscription-edit/page.js
@@ -1,9 +1,9 @@
 import React from 'react'
+import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
+import { FormattedMessage, intlShape } from 'react-intl'
 import query from 'querystring'
 import classnames from 'classnames'
 import uuid from 'uuid'
-import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
-import { FormattedMessage } from 'react-intl'
 import { Background } from '~client/components/layout'
 import { CreditCardForm, RecurringForm } from '~client/subscriptions/forms'
 import { FlatForm } from '~client/ux/components'
@@ -82,7 +82,8 @@ const SubscriptionEditPage = props => {
     asyncSubscriptionDelete,
     setModificationType,
     appendAnimationStack,
-    removeAnimationStack
+    removeAnimationStack,
+    intl
   } = props
 
   const displayForm = (form, type) => {
@@ -167,8 +168,17 @@ const SubscriptionEditPage = props => {
           <p className='link--cancel center mt3 lightgray link'>
             <a
               onClick={() => {
-                animationStack.length && removeAnimationStack(0)
-                asyncSubscriptionDelete(initialValues)
+                const message = intl.formatMessage({
+                  id: 'page--subscription-edit.cancel-subscription.confirm',
+                  defaultMessage: 'Você está prestes a cancelar sua assinatura. ' +
+                    'Fazendo isso, você deixa de nos ajudar com suas doações. ' +
+                    'Tem certeza que quer continuar?'
+                })
+
+                if (window.confirm(message)) {
+                  animationStack.length && removeAnimationStack(0)
+                  asyncSubscriptionDelete(initialValues)
+                }
               }}
             >
               <FormattedMessage
@@ -181,6 +191,10 @@ const SubscriptionEditPage = props => {
       </Background>
     </div>
   )
+}
+
+SubscriptionEditPage.propTypes = {
+  intl: intlShape.isRequired
 }
 
 export default SubscriptionEditPage

--- a/routes/public/subscription-edit/page.scss
+++ b/routes/public/subscription-edit/page.scss
@@ -1,3 +1,16 @@
+.routes--subscription-edit-page .link--cancel {
+  margin-bottom: -.5rem;
+}
+
+.routes--subscription-edit-page .link a {
+  font-weight: normal;
+  text-decoration: none;
+  cursor: pointer;
+}
+.routes--subscription-edit-page .link a::after {
+  height: 1px;
+}
+
 .routes--subscription-edit-page {}
 
 .routes--subscription-edit-page .section--choose-type {


### PR DESCRIPTION
# Related issues
- Add button to cancel subscription at edit page #683

# How to test
- Get a subscription on the db using the SQL query below:

```sql
SELECT id,
       token
FROM subscriptions
WHERE payment_method = 'credit_card'
  AND status = 'paid' LIMIT 1;
```

- Replace the values in the URL:
`http://app.staging.bonde.org/subscriptions/${id}/edit?token=${token}`

- The page should contain a link that provide a way to cancel the subscription

| before | expected |
|---|---|
| <img width="604" alt="screen shot 2017-06-20 at 15 51 33" src="https://user-images.githubusercontent.com/5435389/27350547-057e3c08-55d1-11e7-86a0-60ab4d38bb17.png"> | <img width="590" alt="screen shot 2017-06-20 at 15 51 42" src="https://user-images.githubusercontent.com/5435389/27350546-057c67e8-55d1-11e7-85d7-7496f8e952d3.png"> |

- After click on the link, a confirmation message should appear:

<img width="528" alt="screen shot 2017-06-20 at 16 29 50" src="https://user-images.githubusercontent.com/5435389/27352053-cb873e3c-55d5-11e7-99c0-9204f4ec5062.png">

- If confirm the previous prompt and, the request to cancel the subscription was a success, a notification message should appear on the top right corner of the page:

<img width="385" alt="screen shot 2017-06-20 at 16 30 02" src="https://user-images.githubusercontent.com/5435389/27352063-d1186df8-55d5-11e7-8103-2c0c35521e66.png">

- Otherwise, a generic request notification message should appear:

<img width="382" alt="screen shot 2017-06-20 at 16 00 52" src="https://user-images.githubusercontent.com/5435389/27350763-acbcb6ac-55d1-11e7-979d-fa6cb35a2412.png">
