### PR TITLE
Hotfix community invite role payload

### DIFF
--- a/client/community/action-creators/async-invite.js
+++ b/client/community/action-creators/async-invite.js
@@ -4,11 +4,17 @@ import * as t from '~client/community/action-types'
 import * as AwaitActions from '~client/components/await/redux/action-creators'
 import { genericRequestError, communityInviteSuccess } from '~client/utils/notifications'
 
+const COMMUNITY_USER_ROLES = {
+  owner: 1,
+  admin: 2,
+  participant: 3
+}
+
 export default (communityId, invitation) => (dispatch, getState, { api, intl }) => {
   const { auth: { credentials } } = getState()
 
   const endpoint = `/communities/${communityId}/invitation`
-  const body = { invitation }
+  const body = { invitation: { ...invitation, role: COMMUNITY_USER_ROLES.admin } }
   const options = { headers: credentials }
 
   dispatch(AwaitActions.setLoading(true))


### PR DESCRIPTION
# Related issues
- Tells which role must provide to an invited mobilizer #693

# How to test
- Log into BONDE
- Choose a community in community list page
- Access the **Mobilizers** community settings page (routes: `/community/invite`)
- Send an invitation to an email of your preference
- On db, use the SQL query below to validate the creation of an invite on the **invitations** table

```sql
SELECT *
FROM invitations
ORDER BY id DESC LIMIT 1;
```

- It should match with values that you have inputed