### PR TITLE
Feature upgrade slate editor to v2.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "redux-logger": "^2.7.4",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.1.0",
-    "slate-editor": "2.6.5",
+    "slate-editor": "2.6.6",
     "slug": "^0.9.1",
     "superagent": "^3.3.2",
     "throng": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7420,9 +7420,9 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate-editor@2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/slate-editor/-/slate-editor-2.6.5.tgz#ca707013c09851586cedee6120b62e491f2aa662"
+slate-editor@2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/slate-editor/-/slate-editor-2.6.6.tgz#0eb112599ca2fe7f3d92886b329374448db6926d"
   dependencies:
     classnames "^2.2.5"
     exenv "^1.2.1"


### PR DESCRIPTION
# Related issues
- Update slate editor to use pt-br labels #688

# How to test
- Follow the step described in [slate-editor](https://github.com/nossas/slate-editor) repo PR:
**Feature set default language to pt-BR** nossas/slate-editor#32