### PR TITLE
Hotfix custom domain validation

### DIFF
--- a/client/mobilizations/components/form-domain.connected.js
+++ b/client/mobilizations/components/form-domain.connected.js
@@ -37,6 +37,9 @@ export const validate = (values, props) => {
   if (values.rootDomainConfig && !values.rootDomain) {
     errors.rootDomain = 'Preenchimento obrigatório'
   }
+  if (values.subdomain && !/^[\w\-]+$/.test(values.subdomain)) {
+    errors.subdomain = 'Informe um subdomínio válido'
+  }
   if (values.externalDomain && !isValidDomain(values.externalDomain)) {
     errors.externalDomain = 'Informe um domínio válido'
   }
@@ -46,6 +49,7 @@ export const validate = (values, props) => {
 
 const mapStateToProps = (state, props) => {
   const { custom_domain: customDomain } = props.mobilization
+
   if (customDomain) {
     const hasWWW = customDomain.startsWith('www.')
     /* eslint-disable no-useless-escape */

--- a/client/utils/validation-helper.js
+++ b/client/utils/validation-helper.js
@@ -2,7 +2,7 @@
 const regexEmail = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 export const isValidEmail = email => regexEmail.test(email)
 
-const regexDomain = /^(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/i
+const regexDomain = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/
 export const isValidDomain = domain => regexDomain.test(domain)
 
 // Validates Google Analytics Code


### PR DESCRIPTION
## Issues:

- Add validation to custom_domain at mobilizations with invalid characters "ç". Closes #698

## How to test

You can test inserting a value on domain's input, like this pages:

- [x] `/mobilizations/[:mobilization_id]/launch`
- [x] `/mobilizations/[:mobilization_id]/customDomain`
- [x] `/community/domain/add`