### PR TITLE
Hotfix avoid self pressure sender email

### DIFF
--- a/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
@@ -124,6 +124,7 @@ export class Pressure extends Component {
               subject={pressureSubject}
               body={pressureBody}
               onSubmit={::this.handleSubmit}
+              targetList={this.getTargetList()}
             >
               {!showCounter || showCounter !== 'true' ? null : (
                 <PressureCount

--- a/client/mobilizations/widgets/__plugins__/pressure/components/pressure-form/index.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/pressure-form/index.js
@@ -1,14 +1,10 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import classnames from 'classnames'
-
-// Global module dependencies
 import { isValidEmail } from '~client/utils/validation-helper'
-
-// Current module dependencies
-if (require('exenv').canUseDOM) require('./index.scss')
-
 import AnalyticsEvents from '~client/mobilizations/widgets/utils/analytics-events'
+
+if (require('exenv').canUseDOM) require('./index.scss')
 
 // TODO: Reusable Input
 const controlClassname = 'px3 py1'
@@ -33,35 +29,35 @@ class PressureForm extends Component {
   }
 
   validate () {
-    const { widget: { settings: { show_city: showCity } } } = this.props
+    const { targetList, widget: { settings: { show_city: showCity } } } = this.props
     const requiredMsg = 'Preenchimento obrigatório'
     const errors = { valid: true }
+
     if (!this.state.email) {
-      errors.valid = false
       errors.email = requiredMsg
     } else if (!isValidEmail(this.state.email)) {
-      errors.valid = false
       errors.email = 'E-mail inválido'
+    } else if (targetList.some(target => target.match(`<${this.state.email}>`))) {
+      errors.email = 'O email que você está tentando usar é de um dos alvos da mobilização.'
     }
     if (!this.state.name) {
-      errors.valid = false
       errors.name = requiredMsg
     }
     if (!this.state.lastname) {
-      errors.valid = false
       errors.lastname = requiredMsg
     }
     if (showCity === 'city-true' && !this.state.city) {
-      errors.valid = false
       errors.city = requiredMsg
     }
     if (!this.state.subject) {
-      errors.valid = false
       errors.subject = requiredMsg
     }
     if (!this.state.body) {
-      errors.valid = false
       errors.body = requiredMsg
+    }
+
+    if (Object.keys(errors).length > 1) {
+      errors.valid = false
     }
     return errors
   }

--- a/client/mobilizations/widgets/__plugins__/pressure/components/pressure-form/index.spec.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/pressure-form/index.spec.js
@@ -6,10 +6,11 @@ import { PressureForm } from '~client/mobilizations/widgets/__plugins__/pressure
 
 describe('client/mobilizations/widgets/__plugins__/pressure/components/pressure-form', () => {
   let wrapper
+  const targets = ['foo@bar.com', 'bar@foo.com', 'foo@baz.com']
   const widget = { settings: {} }
 
   beforeEach(() => {
-    wrapper = mount(<PressureForm widget={widget} />)
+    wrapper = mount(<PressureForm widget={widget} targetList={targets} />)
   })
 
   it('should render ok by default', () => {

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -1021,6 +1021,25 @@ export default {
   //   - (public) /
   'form-widget.components--tell-a-friend.message': 'Formulário submetido com sucesso!',
 
+  // component pressure widget form
+  // filepath: /client/mobilizations/widgets/__plugins__/pressure/components/pressure-form/index.js
+  // routepath:
+  //   - /mobilizations/:mobilization_id/edit
+  //   - (public) /
+  'pressure-widget.components--pressure-form.validation.required': 'Preenchimento obrigatório',
+  'pressure-widget.components--pressure-form.email.label': 'E-mail',
+  'pressure-widget.components--pressure-form.email.placeholder': 'Insira seu e-mail',
+  'pressure-widget.components--pressure-form.email.validation.invalid-email-format': 'E-mail inválido',
+  'pressure-widget.components--pressure-form.email.validation.sender-is-target': 'O email que você está tentando usar é de um dos alvos da mobilização.',
+  'pressure-widget.components--pressure-form.name.label': 'Nome',
+  'pressure-widget.components--pressure-form.name.placeholder': 'Insira seu nome',
+  'pressure-widget.components--pressure-form.lastname.label': 'Sobrenome',
+  'pressure-widget.components--pressure-form.lastname.placeholder': 'Insira seu sobrenome',
+  'pressure-widget.components--pressure-form.city.label': 'Cidade',
+  'pressure-widget.components--pressure-form.city.placeholder': 'Insira sua cidade',
+  'pressure-widget.components--pressure-form.subject.label': 'Assunto',
+  'pressure-widget.components--pressure-form.body.label': 'Corpo do e-mail',
+
   // component pressure widget settings menu
   // filepath: /client/mobilizations/widgets/__plugins__/pressure/components/settings-menu.js
   // routepath:


### PR DESCRIPTION
# Related issues
- Block activists from using target e-mail to create pressure #713

# How to test
- Access a mobilization that contains a pressure widget
- Try to send a pressure using one of the emails of targets that will be pressed
- It should appear an error like screenshot below:

<img width="362" alt="screen shot 2017-06-27 at 18 54 08" src="https://user-images.githubusercontent.com/5435389/27611809-0a87a290-5b6a-11e7-8dc4-9338402469ab.png">
