### PR TITLE
Hotfix add pressure targets kbd shortcut on windows or linux

### DIFF
--- a/client/mobilizations/widgets/__plugins__/pressure/components/pressure-form/index.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/pressure-form/index.js
@@ -37,7 +37,7 @@ class PressureForm extends Component {
       errors.email = requiredMsg
     } else if (!isValidEmail(this.state.email)) {
       errors.email = 'E-mail inválido'
-    } else if (targetList.some(target => target.match(`<${this.state.email}>`))) {
+    } else if (targetList && targetList.some(target => target.match(`<${this.state.email}>`))) {
       errors.email = 'O email que você está tentando usar é de um dos alvos da mobilização.'
     }
     if (!this.state.name) {

--- a/client/mobilizations/widgets/components/input-tag.js
+++ b/client/mobilizations/widgets/components/input-tag.js
@@ -22,14 +22,12 @@ class InputTag extends Component {
     //
     // watch the keyboard event to dispatch the trigger to add targets
     // Mac      : cmd + enter
-    // Windows  : ctrl + enter
-    // Linux    : ctrl + enter
+    // Default  : ctrl + enter
     //
     const mac = os.isMac() && keycode(e) === 'enter' && e.nativeEvent.metaKey
-    const windows = os.isWindows() && keycode(e) === 'enter' && e.ctrlKey
-    const linux = (os.isLinux() || os.isUnix()) && keycode(e) === 'enter' && e.ctrlKey
+    const def = keycode(e) === 'enter' && e.ctrlKey
 
-    if (mac || windows || linux) {
+    if (mac || def) {
       e.preventDefault()
       const { onInsertTag, validate } = this.props
       const targets = e.target.value.split('\n')

--- a/client/mobilizations/widgets/components/input-tag.js
+++ b/client/mobilizations/widgets/components/input-tag.js
@@ -26,8 +26,8 @@ class InputTag extends Component {
     // Linux    : ctrl + enter
     //
     const mac = os.isMac() && keycode(e) === 'enter' && e.nativeEvent.metaKey
-    const windows = os.isWindows() && keycode(e) === 'enter' && e.nativeEvent.ctrlKey
-    const linux = os.isLinux() && keycode(e) === 'enter' && e.nativeEvent.ctrlKey
+    const windows = os.isWindows() && keycode(e) === 'enter' && e.ctrlKey
+    const linux = (os.isLinux() || os.isUnix()) && keycode(e) === 'enter' && e.ctrlKey
 
     if (mac || windows || linux) {
       e.preventDefault()

--- a/client/mobilizations/widgets/components/input-tag.spec.js
+++ b/client/mobilizations/widgets/components/input-tag.spec.js
@@ -51,10 +51,8 @@ describe('client/mobilizations/widgets/components/input-tag', () => {
     expect(wrapper.find('.red').text()).to.have.string('Dismatch error')
   })
 
-  it('should render error when keyDown `ctrl` + `enter` on Windows and validade returns false',
+  it('should render error when keyDown `ctrl` + `enter` and validade returns false',
     () => {
-      let confirmStub = sinon.stub(os, 'isWindows')
-      confirmStub.returns(true)
       wrapper.find('textarea').simulate('keyDown', {
         charCode: 13,
         ctrlKey: true
@@ -62,16 +60,6 @@ describe('client/mobilizations/widgets/components/input-tag', () => {
       expect(wrapper.find('.red').text()).to.have.string('Dismatch error')
     }
   )
-
-  it('should render error when keyDown `ctrl` + `enter` on Linux and validade returns false', () => {
-    let confirmStub = sinon.stub(os, 'isLinux')
-    confirmStub.returns(true)
-    wrapper.find('textarea').simulate('keyDown', {
-      charCode: 13,
-      ctrlKey: true
-    })
-    expect(wrapper.find('.red').text()).to.have.string('Dismatch error')
-  })
 
   it('should clean and call onInsertTag when keyDown `cmd` + `enter` and validade return is true',
     () => {

--- a/client/mobilizations/widgets/components/input-tag.spec.js
+++ b/client/mobilizations/widgets/components/input-tag.spec.js
@@ -57,7 +57,7 @@ describe('client/mobilizations/widgets/components/input-tag', () => {
       confirmStub.returns(true)
       wrapper.find('textarea').simulate('keyDown', {
         charCode: 13,
-        nativeEvent: { ctrlKey: true }
+        ctrlKey: true
       })
       expect(wrapper.find('.red').text()).to.have.string('Dismatch error')
     }
@@ -68,7 +68,7 @@ describe('client/mobilizations/widgets/components/input-tag', () => {
     confirmStub.returns(true)
     wrapper.find('textarea').simulate('keyDown', {
       charCode: 13,
-      nativeEvent: { ctrlKey: true }
+      ctrlKey: true
     })
     expect(wrapper.find('.red').text()).to.have.string('Dismatch error')
   })


### PR DESCRIPTION
# Related issues
- Add targets into widget's pressure can't be done in win/linux #725
- TypeError: n.some is not a function #728

# How to test
Test cases by issue:

# #725
- Log into BONDE using **Windows** or **Linux** OS
- Choose a community on the community list page
- Choose a mobilization that contains a pressure widget
- Hover on pressure widget, and click on edit button to access the settings page
- On the pressure widget settings page, click on the **Email** tab
(route: `mobilizations/:mobilization_id/widgets/:widget_id/pressure/email`)
- The info text on top of the page should instruct to use the <kbd>ctrl</kbd> + <kbd>enter</kbd> keyboard shortcut to add targets
<img width="1097" alt="screen shot 2017-07-03 at 18 28 35" src="https://user-images.githubusercontent.com/5435389/27808355-aaf81ebe-601d-11e7-8144-df44b6248a5e.png">

- When hit <kbd>ctrl</kbd> + <kbd>enter</kbd>, after filling up the text area with targets with a valid format, it should add to the target list.

# #728 
- Open a mobilization via public view that contains a pressure widget that have 0 targets
- Make a pressure
- No error should be displayed on the console