### PR TITLE
Feature optional slug field on mobilization create

### DIFF
--- a/client/components/markdown/code.js
+++ b/client/components/markdown/code.js
@@ -2,8 +2,8 @@ import React from 'react'
 
 var styles = require('exenv').canUseDOM ? require('./code.scss') : {}
 
-export default ({ children }) => (
-  <span className={styles.code}>
+export default ({ children, bordered }) => (
+  <span className={bordered ? styles.bordered : styles.code}>
     {children}
   </span>
 )

--- a/client/components/markdown/code.scss
+++ b/client/components/markdown/code.scss
@@ -4,4 +4,11 @@
     background-color: #efefef;
     border-radius: 2px;
   }
+
+  .bordered {
+    composes: code;
+    background-color: #ffffff;
+    border: 1px solid rgba(0,0,0,.12);
+    font-style: normal;
+  }
 }

--- a/client/mobilizations/components/mobilization-basics-form.js
+++ b/client/mobilizations/components/mobilization-basics-form.js
@@ -1,13 +1,21 @@
 import React from 'react'
+import classnames from 'classnames'
 import { connect } from 'react-redux'
 import { addNotification as notify } from 'reapop'
 import { injectIntl, intlShape } from 'react-intl'
 import { Info } from '~client/components/notify'
 import { slugUpdatedMessage } from '~client/utils/notifications'
 import { slugify } from '~client/utils/string-helper'
-import { FormRedux, FormGroup, ControlLabel, FormControl } from '~client/components/forms'
 import { SettingsForm } from '~client/ux/components'
 import { Code } from '~client/components/markdown'
+import {
+  FormRedux,
+  FormGroup,
+  ControlLabel,
+  FormControl,
+  HelpBlock
+} from '~client/components/forms'
+import * as paths from '~client/paths'
 
 export const MobilizationBasicsForm = ({
   fields: { name, slug, goal },
@@ -15,6 +23,8 @@ export const MobilizationBasicsForm = ({
   ...formProps
 }) => {
   const ComponentForm = floatSubmit ? SettingsForm : FormRedux
+  const { location: { pathname } } = formProps
+  const isNewMobilizationPath = pathname === paths.newMobilization()
 
   return (
     <ComponentForm {...formProps}>
@@ -33,17 +43,6 @@ export const MobilizationBasicsForm = ({
           maxLength={100}
         />
       </FormGroup>
-      <FormGroup controlId='slug' {...slug} className='hide'>
-        <ControlLabel maxLength={63}>Identificador Único</ControlLabel>
-        <Info title='Pra que serve?'>
-          O valor desse campo é utilizado para referenciar a mobilização no domínio do BONDE,
-          por exemplo: <Code>www.123-nome-da-mob.bonde.org</Code>
-        </Info>
-        <FormControl
-          type='text'
-          maxLength={63}
-        />
-      </FormGroup>
       <FormGroup controlId='goal' {...goal}>
         <ControlLabel maxLength={500}>Objetivo</ControlLabel>
         <FormControl
@@ -52,6 +51,22 @@ export const MobilizationBasicsForm = ({
             ' sua mobilização. Você poderá alterar este texto depois.'}
           maxLength={500}
           rows='4'
+        />
+      </FormGroup>
+      <FormGroup
+        {...slug}
+        controlId='slug'
+        className={classnames({ hide: isNewMobilizationPath })}
+      >
+        <ControlLabel maxLength={63}>Identificador Único</ControlLabel>
+        <HelpBlock>
+          O valor desse campo é utilizado para referenciar a mobilização no domínio do BONDE,
+          por exemplo: <Code bordered>www.123-nome-da-mob.bonde.org</Code>
+        </HelpBlock>
+        <FormControl
+          type={isNewMobilizationPath ? 'hidden' : 'text'}
+          maxLength={63}
+          placeholder='Ex: 123-nome-da-mob'
         />
       </FormGroup>
     </ComponentForm>
@@ -74,9 +89,7 @@ export const validate = values => {
     errors.goal = 'O limite de caracteres foi atingido.'
   }
 
-  if (!values.slug) {
-    errors.slug = 'Insira o identificador único da mobilização'
-  } else if (values.slug.length > 63) {
+  if (values.slug && values.slug.length > 63) {
     errors.slug = 'Seu identificador único está muito longo!'
   }
 


### PR DESCRIPTION
# Related issues
- field slug from mobilization must roll back to be not required #726

# How to test
Test cases by route

## Mobilization basic info settings page
- Access the mobilization's basic info settings page
(route: `/mobilizations/:mobilization_id/basics`)
- It should display the **slug** field to fill, and it should be optional
<img width="1280" alt="screen shot 2017-07-04 at 09 06 47" src="https://user-images.githubusercontent.com/5435389/27829529-577802f6-6098-11e7-912b-7c468d48242d.png">

## New mobilization page
- Access the page to create a new mobilization (route: `/mobilizations/new`)
- It should **not** display the **slug** field (should not focus on the input with <kbd>tab</kbd>)
<img width="1589" alt="screen shot 2017-07-04 at 09 09 54" src="https://user-images.githubusercontent.com/5435389/27829608-be99738e-6098-11e7-89be-2581478bed0b.png">
