### PR TITLE
Feature create easily mobilization

### DIFF
--- a/client/components/forms/control-buttons.js
+++ b/client/components/forms/control-buttons.js
@@ -5,17 +5,26 @@ import classnames from 'classnames'
 class ControlButtons extends Component {
   render () {
     const { $formRedux: { floatButton, successMessage } } = this.context
-    const { submitting, submitted, dirty, formInline, valid } = this.props
+    const { onCancel, submitting, submitted, dirty, formInline, valid } = this.props
     return (
       <div className={classnames(
           'control-buttons',
           formInline ? 'inline-block ml1' : 'flex flex-wrap mt1'
       )}>
+        {onCancel && (
+          <button
+            className='btn h3 col-4 ml2 white mt1 mb2 p2 rounded bg-gray'
+            onClick={onCancel}
+          >
+            Voltar
+          </button>
+        )}
         <input
           type='submit'
           className={classnames(
-            'btn h3 col-12 mt1 mb2 mx2 white p2 rounded',
-            !valid ? 'bg-gray95' : 'bg-pagenta'
+            'btn h3 mt1 mb2 white p2 rounded',
+            !valid ? 'bg-gray95' : 'bg-pagenta',
+            onCancel ? 'col-7 ml3' : 'col-12 mx2'
           )}
           disabled={!valid || submitting || !dirty}
           value={(submitting ? 'Salvando...' : (floatButton || 'Continuar'))}

--- a/client/components/forms/control-buttons.spec.js
+++ b/client/components/forms/control-buttons.spec.js
@@ -32,12 +32,17 @@ describe('client/components/forms/control-buttons', () => {
     })
   })
 
-  describe('without cancel button', () => {
+  describe('with cancel button', () => {
     beforeAll(() => {
-      wrapper = shallow(<ControlButtons {...{ ...props, showCancel: false }} />, { context })
+      wrapper = shallow(<ControlButtons {...{ ...props }} />, { context })
     })
-    it('should not render cancel button', () => {
-      expect(wrapper.find('button')).to.have.length(0)
+    it('should render cancel button when pass onCancel', () => {
+      let called
+      wrapper.setProps({ onCancel: () => { called = true } })
+      expect(wrapper.find('button')).to.have.length(1)
+
+      wrapper.find('button').simulate('click')
+      expect(called).to.equal(true)
     })
   })
 

--- a/client/components/forms/form-redux/index.js
+++ b/client/components/forms/form-redux/index.js
@@ -47,7 +47,8 @@ class FormRedux extends Component {
       className,
       floatButton,
       nosubmit,
-      style
+      style,
+      onCancel
     } = this.props
     const { submitted } = this.state
 
@@ -62,7 +63,7 @@ class FormRedux extends Component {
         )}
       >
         {children}
-        {!inline && !nosubmit && <ControlButtons {...{ submitted, submitting, dirty, valid }} />}
+        {!inline && !nosubmit && <ControlButtons {...{ submitted, submitting, dirty, valid, onCancel }} />}
       </form>
     )
   }

--- a/client/components/forms/form-redux/index.spec.js
+++ b/client/components/forms/form-redux/index.spec.js
@@ -29,6 +29,12 @@ describe('client/components/forms/form-redux', () => {
     expect(wrapper.instance().state.submitted).to.equal(true)
   })
 
+  it('should pass onCancel for <ControlButtons />', () => {
+    const onCancel = () => {}
+    wrapper.setProps({ onCancel })
+    expect(wrapper.find('ControlButtons').props().onCancel).to.equal(onCancel)
+  })
+
   describe('default', () => {
     it('className prop should be as default', () => {
       expect(wrapper.props().className).to.be.a.string

--- a/client/components/navigation/browsable-list/browsable-list-item.js
+++ b/client/components/navigation/browsable-list/browsable-list-item.js
@@ -7,15 +7,25 @@ if (require('exenv').canUseDOM) {
   require('./browsable-list-item.scss')
 }
 
-const BrowsableListItem = ({ className, style, leftIcon, title, subtitle, rightIcon, path }) => (
-  <Link className={classnames('browsable-list-item', className)} style={style} to={path}>
-    <i className={`bg-animation-icon fa fa-${rightIcon}`} />
-    <i className={`icon left-icon fa fa-${leftIcon}`} />
-    <span className='title'>{title}</span>
-    <span className='subtitle'>{subtitle}</span>
-    <i className={`icon right-icon fa fa-${rightIcon}`} />
-  </Link>
-)
+const BrowsableListItem = ({ className, style, leftIcon, title, subtitle, rightIcon, path, onClick }) => {
+  const Component = path ? Link : 'div'
+  const componentProps = path
+    ? { to: path }
+    : { style: { cursor: 'pointer' }, onClick }
+
+  return (
+    <Component
+      className={classnames('browsable-list-item', className)}
+      {...componentProps}
+    >
+      <i className={`bg-animation-icon fa fa-${rightIcon}`} />
+      <i className={`icon left-icon fa fa-${leftIcon}`} />
+      <span className='title'>{title}</span>
+      <span className='subtitle'>{subtitle}</span>
+      <i className={`icon right-icon fa fa-${rightIcon}`} />
+    </Component>
+  )
+}
 
 BrowsableListItem.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),

--- a/client/mobilizations/components/list/items/created-at.js
+++ b/client/mobilizations/components/list/items/created-at.js
@@ -1,14 +1,15 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const CreatedAt = ({ created_at }) => (
+const CreatedAt = ({ created_at, createdAt }) => (
   <div className='created-at px3 col col-3'>
-    {new Date(Date.parse(created_at)).toLocaleString()}
+    {new Date(Date.parse(created_at || createdAt)).toLocaleString()}
   </div>
 )
 
 CreatedAt.propTypes = {
-  created_at: PropTypes.string.isRequired
+  created_at: PropTypes.string,
+  createdAt: PropTypes.string
 }
 
 export default CreatedAt

--- a/client/mobrender/redux/action-creators/async-update-mobilization.js
+++ b/client/mobrender/redux/action-creators/async-update-mobilization.js
@@ -1,6 +1,9 @@
 import { createAction } from './create-action'
 import * as t from '../action-types'
 
+import asyncFetchBlocks from './async-fetch-blocks'
+import asyncFetchWidgets from './async-fetch-widgets'
+
 export default ({ fieldName, ...mobilization }) =>
   (dispatch, getState, { api }) => {
     const { auth: { credentials } } = getState()
@@ -12,6 +15,10 @@ export default ({ fieldName, ...mobilization }) =>
       .put(endpoint, { mobilization }, config)
       .then(({ status, data }) => {
         dispatch({ type: t.UPDATE_MOBILIZATION_SUCCESS, payload: data })
+        if (mobilization.template_mobilization_id) {
+          dispatch(asyncFetchBlocks(data.id))
+          dispatch(asyncFetchWidgets(data.id))
+        }
         return Promise.resolve(data)
       })
       .catch(({ ...errors, response }) => {

--- a/client/mobrender/redux/selectors.js
+++ b/client/mobrender/redux/selectors.js
@@ -3,7 +3,13 @@ export default (state, props) => ({
 
   getMobilization: () => {
     const { list: { currentId, data } } = state.mobilizations
-    return data.filter(mob => mob.id === currentId)[0]
+
+    const mobilization = (id) => data.filter(mob => mob.id === id)[0]
+
+    if (!currentId && props && props.params && props.params.mobilization_id) {
+      return mobilization(parseInt(props.params.mobilization_id))
+    }
+    return mobilization(currentId)
   },
 
   mobilizationsIsLoading: () => {

--- a/routes/admin/authenticated/sidebar/mobilizations-edit/page.js
+++ b/routes/admin/authenticated/sidebar/mobilizations-edit/page.js
@@ -15,7 +15,7 @@ export class MobilizationsEditPage extends Component {
   componentWillReceiveProps (nextProps) {
     const { mobilization, blocksIsLoaded, blocks } = nextProps
     if (blocksIsLoaded && blocks.length === 0) {
-      browserHistory.push(paths.createBlock(mobilization))
+      browserHistory.push(paths.mobilizationTemplatesChoose(mobilization))
     }
   }
 

--- a/routes/admin/authenticated/sidebar/templates-choose-custom/page.js
+++ b/routes/admin/authenticated/sidebar/templates-choose-custom/page.js
@@ -4,30 +4,45 @@ import { browserHistory } from 'react-router'
 import * as paths from '~client/paths'
 import { PageTabLayout } from '~client/mobilizations/components'
 import { TemplateSelectableList } from '~client/mobilizations/templates/components'
+import { Loading } from '~client/components/await'
 
-const TemplatesChooseCustomPage = ({
-  mobilization,
-  createMobilizationFromTemplate,
-  location,
-  ...listableProps
-}) => (
-  <PageTabLayout {...{ location }}>
-    <div className='choose-custom-page col-12'>
-      <h3 className='h1 mt0 mb3 center'>Meus Templates</h3>
-      <TemplateSelectableList
-        {...listableProps}
-        handleGoBack={() => browserHistory.goBack()}
-        handleSelectItem={({ id: template_mobilization_id }) => {
-          createMobilizationFromTemplate({ id: mobilization.id, template_mobilization_id })
-            .then(() => {
-              browserHistory.push(paths.editMobilization(mobilization.id))
-              return Promise.resolve()
-            })
-            .catch(error => console.error('CreateMobilizationFromTemplateAsyncError', error))
-        }}
-      />
-    </div>
-  </PageTabLayout>
-)
+class TemplatesChooseCustomPage extends React.Component {
+
+  componentDidMount () {
+    if (this.props.templates) {
+      this.props.setFilterableSearchBarList(this.props.templates)
+    }
+  }
+
+  render () {
+    const {
+      mobilization,
+      createMobilizationFromTemplate,
+      location,
+      loading,
+      ...listableProps
+    } = this.props
+    
+    return loading ? <Loading /> : (
+      <PageTabLayout {...{ location }}>
+        <div className='choose-custom-page col-12'>
+          <h3 className='h1 mt0 mb3 center'>Meus Templates</h3>
+          <TemplateSelectableList
+            {...listableProps}
+            handleGoBack={() => browserHistory.goBack()}
+            handleSelectItem={({ id: template_mobilization_id }) => {
+              createMobilizationFromTemplate({ id: mobilization.id, template_mobilization_id })
+                .then(() => {
+                  browserHistory.push(paths.editMobilization(mobilization.id))
+                  return Promise.resolve()
+                })
+                .catch(error => console.error('CreateMobilizationFromTemplateAsyncError', error))
+            }}
+          />
+        </div>
+      </PageTabLayout>
+    )
+  }
+}
 
 export default TemplatesChooseCustomPage

--- a/routes/admin/authenticated/sidebar/templates-choose/page.connected.js
+++ b/routes/admin/authenticated/sidebar/templates-choose/page.connected.js
@@ -1,10 +1,12 @@
 import { provideHooks } from 'redial'
 import { connect } from 'react-redux'
+import { browserHistory } from 'react-router'
 
 import MobSelectors from '~client/mobrender/redux/selectors'
-import { selectMobilization } from '~client/mobrender/redux/action-creators'
+import { selectMobilization, asyncUpdateMobilization } from '~client/mobrender/redux/action-creators'
 import * as TemplateActions from '~client/mobilizations/templates/action-creators'
 import * as TemplateSelectors from '~client/mobilizations/templates/selectors'
+import * as paths from '~client/paths'
 
 import Page from './page'
 
@@ -26,8 +28,22 @@ const redial = {
 
 const mapStateToProps = state => ({
   mobilization: MobSelectors(state).getMobilization(),
-  templatesGlobalLength: TemplateSelectors.getGlobalTemplates(state).length,
+  templatesGlobal: TemplateSelectors.getGlobalTemplates(state),
   templatesCustomLength: TemplateSelectors.getCustomTemplates(state).length
 })
 
-export default provideHooks(redial)(connect(mapStateToProps)(Page))
+const mapActionsToProps = (dispatch, props) => ({
+  createMobilizationFromTemplate: ({ mobilization, template }) => {
+    dispatch(asyncUpdateMobilization({
+      id: mobilization.id,
+      template_mobilization_id: template.id
+    }))
+    .then(() => {
+      browserHistory.push(paths.editMobilization(mobilization.id))
+    })
+  }
+})
+
+export default provideHooks(redial)(
+  connect(mapStateToProps, mapActionsToProps)(Page)
+)

--- a/routes/admin/authenticated/sidebar/templates-choose/page.js
+++ b/routes/admin/authenticated/sidebar/templates-choose/page.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 
 import * as paths from '~client/paths'
 import { BrowsableList, BrowsableListItem } from '~client/components/navigation/browsable-list'
+import { Loading } from '~client/components/await'
 import { PageTabLayout } from '~client/mobilizations/components'
 
 class TemplatesChoosePage extends Component {
@@ -9,18 +10,21 @@ class TemplatesChoosePage extends Component {
   render () {
     const {
       mobilization,
-      templatesGlobal,
-      templatesCustomLength,
+      loading,
+      customTemplatesLength,
+      globalTemplates,
       createMobilizationFromTemplate,
       location
     } = this.props
+
+    if (loading) return <Loading />
     
     return (
       <PageTabLayout {...{ location }}>
         <div className='choose-menu-page col-12'>
           <h3 className='h1 mt0 mb3 center'>Como você deseja começar?</h3>
           <BrowsableList>
-            {templatesGlobal && templatesGlobal.map(template => (
+            {globalTemplates && globalTemplates.map(template => (
               <BrowsableListItem
                 key={`index-${template.id}`}
                 leftIcon={template.goal}
@@ -33,7 +37,7 @@ class TemplatesChoosePage extends Component {
             <BrowsableListItem
               leftIcon='columns'
               title='Meus templates'
-              subtitle={templatesCustomLength}
+              subtitle={customTemplatesLength}
               path={paths.mobilizationTemplatesChooseCustomList(mobilization)}
             />
           </BrowsableList>

--- a/routes/admin/authenticated/sidebar/templates-choose/page.js
+++ b/routes/admin/authenticated/sidebar/templates-choose/page.js
@@ -1,39 +1,46 @@
-import React from 'react'
+import React, { Component } from 'react'
 
 import * as paths from '~client/paths'
 import { BrowsableList, BrowsableListItem } from '~client/components/navigation/browsable-list'
 import { PageTabLayout } from '~client/mobilizations/components'
 
-const TemplatesChoosePage = ({
-  mobilization,
-  templatesGlobalLength,
-  templatesCustomLength,
-  location
-}) => (
-  <PageTabLayout {...{ location }}>
-    <div className='choose-menu-page col-12'>
-      <h3 className='h1 mt0 mb3 center'>Como você deseja começar?</h3>
-      <BrowsableList>
-        <BrowsableListItem
-          leftIcon='plus-square-o'
-          title='Criar mobilização do zero'
-          path={paths.createBlock(mobilization)}
-        />
-        <BrowsableListItem
-          leftIcon='columns'
-          title='Meus templates'
-          subtitle={templatesCustomLength}
-          path={paths.mobilizationTemplatesChooseCustomList(mobilization)}
-        />
-        <BrowsableListItem
-          leftIcon='globe'
-          title='Templates globais'
-          subtitle={templatesGlobalLength}
-          path={paths.mobilizationTemplatesChooseGlobalList(mobilization)}
-        />
-      </BrowsableList>
-    </div>
-  </PageTabLayout>
-)
+class TemplatesChoosePage extends Component {
+
+  render () {
+    const {
+      mobilization,
+      templatesGlobal,
+      templatesCustomLength,
+      createMobilizationFromTemplate,
+      location
+    } = this.props
+    
+    return (
+      <PageTabLayout {...{ location }}>
+        <div className='choose-menu-page col-12'>
+          <h3 className='h1 mt0 mb3 center'>Como você deseja começar?</h3>
+          <BrowsableList>
+            {templatesGlobal && templatesGlobal.map(template => (
+              <BrowsableListItem
+                key={`index-${template.id}`}
+                leftIcon={template.goal}
+                title={template.name}
+                onClick={() => {
+                  createMobilizationFromTemplate({ mobilization, template })
+                }}
+              />
+            ))}
+            <BrowsableListItem
+              leftIcon='columns'
+              title='Meus templates'
+              subtitle={templatesCustomLength}
+              path={paths.mobilizationTemplatesChooseCustomList(mobilization)}
+            />
+          </BrowsableList>
+        </div>
+      </PageTabLayout>
+    )
+  }
+}
 
 export default TemplatesChoosePage

--- a/routes/admin/authenticated/sidebar/templates-create/page.js
+++ b/routes/admin/authenticated/sidebar/templates-create/page.js
@@ -38,6 +38,9 @@ const TemplatesCreatePage = ({ mobilization, fields: { name, goal }, ...formProp
 
       <FormRedux
         className='bg-white'
+        onCancel={() => {
+          browserHistory.push(paths.mobilizations()) 
+        }}
         onFinishSubmit={() => {
           browserHistory.push(paths.mobilizations())
         }}


### PR DESCRIPTION
# Issues

- Add button to cancel at form create template. Closes #689
- Remove option to create empty mobilizations and global template. Closes #691
- Add shortcuts to global templates - Mobilization Tutorial. Closes #692

**NOTE:** Change fetch of templates global and custom to use GraphQL