### PR TITLE
Hotfix community recipient document number

### DIFF
--- a/client/community/action-creators/async-edit.js
+++ b/client/community/action-creators/async-edit.js
@@ -3,6 +3,14 @@ import * as t from '~client/community/action-types'
 const asyncEdit = ({ id, ...community }) => (dispatch, getState, { api }) => {
   const { auth: { credentials } } = getState()
 
+  // ensure that the document number value have only numbers
+  const { bank_account: bankAccount } = community.recipient
+  const { document_number: documentNumber } = bankAccount
+  community.recipient.bank_account = {
+    ...bankAccount,
+    document_number: String(documentNumber).replace(/\D/g, '')
+  }
+
   return api
     .put(`/communities/${id}`, { community }, { headers: credentials })
     .then(({ status, data }) => {

--- a/client/subscriptions/forms/credit-card-form.js
+++ b/client/subscriptions/forms/credit-card-form.js
@@ -16,13 +16,7 @@ const CreditCardForm = ({
     expiration,
     cvv
   },
-  card: {
-    brand,
-    first_digits: firstDigits,
-    last_digits: lastDigits,
-    holder_name: holderName,
-    expiration_date: expirationDate
-  },
+  card,
   ...formProps
 }) => (
   <div>
@@ -40,15 +34,19 @@ const CreditCardForm = ({
         será cobrado neste novo cartão ; )
       </p>
 
-      <div className='mb3 lightgray'>
-        <b className='block mb1'>Dados do último cartão</b>
-        <div>
-          <span className='caps'>{brand}: </span>
-          {firstDigits.slice(0, 4)} {firstDigits.slice(4, 6)}XX XXXX {lastDigits}
+      {card && (
+        <div className='mb3 lightgray'>
+          <b className='block mb1'>Dados do último cartão</b>
+          <div>
+            <span className='caps'>{card.brand}: </span>
+            {card.firstDigits.slice(0, 4)} {card.firstDigits.slice(4, 6)}XX XXXX {card.lastDigits}
+          </div>
+          <div>Nome: <span className='caps'>{card.holderName}</span></div>
+          <div>
+            Validade: {card.expirationDate.slice(0, 2)}/{card.expirationDate.slice(2, 4)}
+          </div>
         </div>
-        <div>Nome: <span className='caps'>{holderName}</span></div>
-        <div>Validade: {expirationDate.slice(0, 2)}/{expirationDate.slice(2, 4)}</div>
-      </div>
+      )}
 
       <FormGroup className='mb2' controlId='creditcard' {...creditcard}>
         <ControlLabel>Número</ControlLabel>
@@ -117,7 +115,7 @@ CreditCardForm.propTypes = {
     last_digits: PropTypes.string.isRequired,
     holder_name: PropTypes.string.isRequired,
     expiration_date: PropTypes.string.isRequired
-  }).isRequired
+  })
 }
 
 export const normalizer = {

--- a/client/subscriptions/forms/credit-card-form.js
+++ b/client/subscriptions/forms/credit-card-form.js
@@ -39,11 +39,11 @@ const CreditCardForm = ({
           <b className='block mb1'>Dados do último cartão</b>
           <div>
             <span className='caps'>{card.brand}: </span>
-            {card.firstDigits.slice(0, 4)} {card.firstDigits.slice(4, 6)}XX XXXX {card.lastDigits}
+            {card.first_digits.slice(0, 4)} {card.first_digits.slice(4, 6)}XX XXXX {card.last_digits}
           </div>
-          <div>Nome: <span className='caps'>{card.holderName}</span></div>
+          <div>Nome: <span className='caps'>{card.holder_name}</span></div>
           <div>
-            Validade: {card.expirationDate.slice(0, 2)}/{card.expirationDate.slice(2, 4)}
+            Validade: {card.expiration_date.slice(0, 2)}/{card.expiration_date.slice(2, 4)}
           </div>
         </div>
       )}

--- a/client/subscriptions/redux/selectors/edit.js
+++ b/client/subscriptions/redux/selectors/edit.js
@@ -4,6 +4,10 @@ export default (state, props) => {
   return {
     getModificationType: () => edit.modificationType,
     getAnimationStack: () => edit.animationStack,
-    getCard: () => edit.data.last_donation.gateway_data.card
+    getCard: () => (
+      edit.data &&
+      edit.data.last_donation &&
+      edit.data.last_donation.gateway_data.card
+    )
   }
 }

--- a/routes/public/subscription-edit/page.connected.js
+++ b/routes/public/subscription-edit/page.connected.js
@@ -37,6 +37,6 @@ const mapDispatchToProps = {
   removeAnimationStack
 }
 
-export default injectIntl(provideHooks(redial)(
-  connect(mapStateToProps, mapDispatchToProps)(Page)
-))
+export default provideHooks(redial)(
+  connect(mapStateToProps, mapDispatchToProps)(injectIntl(Page))
+)


### PR DESCRIPTION
# Related issues
- Last Donation not found when editing subscription by user #732
- Bad request when save document number at bank account info page #737

# How to test
Test cases segmented by issue

### #732
- Get a subscription on the db using the SQL query below:

```sql
SELECT id,
       token
FROM subscriptions
WHERE payment_method = 'credit_card'
  AND status = 'paid' LIMIT 1;
```
- Replace the values in the URL:
`http://app.staging.bonde.org/subscriptions/${id}/edit?token=${token}`
- The page should be rendered

### #737
- Access the community's recipient page (route: `/community/recipient`)
- Fill or replace the document number (**CPF / CNPJ** ) field
- Save the form and it should be saved successfully