### PR TITLE
Improve management block on edit mobilization

### DIFF
--- a/client/mobrender/components/add-new-block.scss
+++ b/client/mobrender/components/add-new-block.scss
@@ -1,0 +1,15 @@
+.add-new-block {
+  border: 2px #525256 dashed;
+  display: block;
+  padding: 10px;
+  margin: 5px;
+  text-align: center;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: #525256;
+
+  &:hover {
+    color: #000;
+    border-color: #000;
+  }
+}

--- a/client/mobrender/components/block-config-menu.connected.js
+++ b/client/mobrender/components/block-config-menu.connected.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import Selectors from '../redux/selectors'
-import { asyncMoveUp, asyncMoveDown, asyncUpdateBlock, handleEdit, asyncDestroyBlock } from '../redux/action-creators'
+import { asyncMoveUp, asyncMoveDown, asyncUpdateBlock, handleEdit, asyncDestroyBlock, asyncAddBlock } from '../redux/action-creators'
 import BlockConfigMenu from './block-config-menu'
 
 const mapStateToProps = (state, props) => {
@@ -11,12 +11,33 @@ const mapStateToProps = (state, props) => {
   }
 }
 
-const mapActionsToProps = {
+const mapActionsToProps = (dispatch, props) => ({
   moveUp: asyncMoveUp,
   moveDown: asyncMoveDown,
   update: asyncUpdateBlock,
   onEdit: handleEdit,
-  destroy: asyncDestroyBlock
-}
+  destroy: asyncDestroyBlock,
+  duplicate: ({ mobilization_id, bg_class, bg_image, position, hidden, name, menu_hidden }) => {
+    // Widgets clean
+    const widgetsAttributes = props.widgets.map(
+      ({ kind, settings, sm_size, md_size, lg_size }) => {
+        return { kind, settings, sm_size, md_size, lg_size }
+      }
+    )
+
+    const block = {
+      mobilization_id,
+      bg_class,
+      bg_image,
+      hidden,
+      name,
+      menu_hidden,
+      widgets_attributes: widgetsAttributes,
+      position: position + 1
+    }
+
+    dispatch(asyncAddBlock(block))
+  }
+})
 
 export default connect(mapStateToProps, mapActionsToProps)(BlockConfigMenu)

--- a/client/mobrender/components/block-config-menu.js
+++ b/client/mobrender/components/block-config-menu.js
@@ -5,7 +5,7 @@ import { DropdownMenu, DropdownMenuItem } from '~client/components/dropdown-menu
 
 export const EDIT_KEY = 'background'
 
-const BlockConfigMenu = ({ block, update, destroy, onEdit, canMoveUp, moveUp, canMoveDown, moveDown, display }) => (
+const BlockConfigMenu = ({ block, update, duplicate, destroy, onEdit, canMoveUp, moveUp, canMoveDown, moveDown, display }) => (
   <DropdownMenu
     wrapperClassName={classnames(
       'm1 absolute bottom-0 right-0 z2',
@@ -15,6 +15,11 @@ const BlockConfigMenu = ({ block, update, destroy, onEdit, canMoveUp, moveUp, ca
     buttonClassName='btn bg-darken-4 white rounded'
     icon='cog'
   >
+    <DropdownMenuItem className='btn' onClick={() => duplicate(block)}>
+      <span>
+        <i className='fa fa-clone' /> Duplicar bloco
+      </span>
+    </DropdownMenuItem>
     <DropdownMenuItem
       className='btn'
       onClick={() => onEdit(`${EDIT_KEY}-${block.id}`)}

--- a/client/mobrender/components/block-config-menu.spec.js
+++ b/client/mobrender/components/block-config-menu.spec.js
@@ -15,7 +15,7 @@ describe('~client/mobrender/components/block-config-menu', () => {
 
   it('should render dropdown menu with options to action', () => {
     expect(menuConfig.find('DropdownMenu').length).to.equal(1)
-    expect(menuConfig.find('DropdownMenu').find('DropdownMenuItem').length).to.equal(5)
+    expect(menuConfig.find('DropdownMenu').find('DropdownMenuItem').length).to.equal(6)
   })
 
   it('should hide dropdown menu when display is false', () => {
@@ -31,9 +31,22 @@ describe('~client/mobrender/components/block-config-menu', () => {
   describe('should make menu item', () => {
     let menu
 
-    describe('the first: change background', () => {
+    describe('0: duplicate', () => {
       beforeEach(() => {
         menu = menuConfig.find('DropdownMenuItem').at(0)
+      })
+
+      it('should call duplicate when clicked', () => {
+        let expected
+        menuConfig.setProps({ duplicate: (block) => expected = block })
+        menu.simulate('click')
+        expect(expected).to.deep.equal(props.block)
+      })
+    })
+    
+    describe('1: change background', () => {
+      beforeEach(() => {
+        menu = menuConfig.find('DropdownMenuItem').at(1)
       })
 
       it('should call onEdit("background-{block_id}") when clicked', () => {
@@ -50,9 +63,9 @@ describe('~client/mobrender/components/block-config-menu', () => {
       })
     })
 
-    describe('the second: show/hide block', () => {
+    describe('2: show/hide block', () => {
       beforeEach(() => {
-        menu = menuConfig.find('DropdownMenuItem').at(1)
+        menu = menuConfig.find('DropdownMenuItem').at(2)
       })
 
       it('should call update with block.hidden updated', () => {
@@ -80,12 +93,12 @@ describe('~client/mobrender/components/block-config-menu', () => {
       })
     })
 
-    describe('the third: remove block', () => {
+    describe('3: remove block', () => {
       let confirmStub
 
       beforeEach(() => {
         confirmStub = sinon.stub(window, 'confirm')
-        menu = menuConfig.find('DropdownMenuItem').at(2)
+        menu = menuConfig.find('DropdownMenuItem').at(3)
       })
 
       afterEach(() => {
@@ -112,9 +125,9 @@ describe('~client/mobrender/components/block-config-menu', () => {
       })
     })
 
-    describe('the fourth: move up', () => {
+    describe('4: move up', () => {
       beforeEach(() => {
-        menu = menuConfig.find('DropdownMenuItem').at(3)
+        menu = menuConfig.find('DropdownMenuItem').at(4)
       })
 
       it('should call moveUp(block) when click and canMoveUp', () => {
@@ -140,9 +153,9 @@ describe('~client/mobrender/components/block-config-menu', () => {
       })
     })
 
-    describe('the fifth: move down', () => {
+    describe('5: move down', () => {
       beforeEach(() => {
-        menu = menuConfig.find('DropdownMenuItem').at(4)
+        menu = menuConfig.find('DropdownMenuItem').at(5)
       })
 
       it('should call moveDown(block) when click and canMoveDown', () => {

--- a/client/mobrender/components/block.js
+++ b/client/mobrender/components/block.js
@@ -61,6 +61,7 @@ const Block = ({ block, widgets, editable, hasMouseOver, onMouseOver, onMouseOut
       <div className='relative'>
         <BlockConfigMenu
           block={block}
+          widgets={widgets}
           display={editable && hasMouseOver && !editing && !saving}
         />
       </div>

--- a/client/mobrender/components/mobilization.js
+++ b/client/mobrender/components/mobilization.js
@@ -7,6 +7,8 @@ import Block from './block.connected'
 import Navbar from './navbar'
 import * as paths from '~client/paths'
 
+if (require('exenv').canUseDOM) require('./add-new-block.scss')
+
 class Mobilization extends React.Component {
   constructor (props) {
     super(props)
@@ -129,6 +131,18 @@ class Mobilization extends React.Component {
               widgets={widgets.filter(w => w.block_id === block.id)}
             />
           ))}
+          {editable && (
+            <div
+              className='add-new-block'
+              onClick={() => {
+                browserHistory.push(
+                  paths.createBlock(this.props.mobilization)
+                )
+              }}
+            >
+              <i className='fa fa-plus' /> Adicionar bloco de conteúdo
+            </div>
+          )}
           <div className='col-10 mx-auto'>
             <div className='col col-10'>
               <a


### PR DESCRIPTION
## Issues

- Add shortcut button to create block after last block. Closes #690
- Add option to duplicate block at block menu. Closes #731 

## Blocked by

- https://github.com/nossas/bonde-server/pull/335

## How to test

1. Acesse a edição de mobilização

**Adicionar bloco de conteúdo**

2. No rodapé você deve encontrar um botão "Adicionar bloco de conteúdo"
3. Clique e você deve ser redicionado a página de adicionar bloco em branco.

**Duplicar bloco**

2. Ao abrir o menu do bloco, deve aparecer uma opção "Duplicar bloco"
3. Clique e você deve ver o bloco duplicado abaixo