### PR TITLE
Add warning for any error on domain API request

### DIFF
--- a/client/community/notifications/dns.js
+++ b/client/community/notifications/dns.js
@@ -23,3 +23,14 @@ export const checkDNSFailure = () => ({
   dismissable: true,
   closeButton: false
 })
+
+export const addHostedZoneFailure = () => ({
+  id: 'notify.community.add--dns-hosted-zone--failure',
+  title: 'Ooops!',
+  status: 'error',
+  message: 'Ocorreu um erro no servidor, '+
+    'verifique se este domínio já não foi inserido.',
+  dismissAfter: 0,
+  dismissable: true,
+  closeButton: false
+})

--- a/client/store.js
+++ b/client/store.js
@@ -76,7 +76,7 @@ export function configureStore (initialState, thunkExtraArgument) {
       return response
     },
     ({ response, ...error }) => {
-      if (response.status === 401) {
+      if (response && response.status === 401) {
         store.dispatch(logout())
       }
       return Promise.reject({ response, ...error })

--- a/intl/locale-data/en.js
+++ b/intl/locale-data/en.js
@@ -28,6 +28,7 @@ export default {
 
   'notify.community.check--dns--success': 'DNS servers are synchronized, you can now configure your email and other services, as well as choose the domain of your mobilization.',
   'notify.community.check--dns--failure': 'The sync is still pending, you can try again in a few minutes.',
+  'notify.community.add--dns-hosted-zone--failure': 'There was an error on the server, make sure this domain was not already inserted.',
 
   'notification--slug-updated-message.title': 'Important',
   'notification--slug-updated-message.message': 'The slug of this mobilization was changed. If you do some DNS redirection via CNAME, be sure to update it.'

--- a/routes/admin/authenticated/sidebar/community-settings/domain-create/page.connected.js
+++ b/routes/admin/authenticated/sidebar/community-settings/domain-create/page.connected.js
@@ -5,8 +5,9 @@ import { addNotification as notify } from 'reapop'
 
 import { isValidDomain } from '~client/utils/validation-helper'
 import DnsControlSelectors from '~client/community/dns-control-selectors'
+import * as dnsNotify from '~client/community/notifications/dns'
 import {
-  asyncAddHostedZone,
+  asyncAddHostedZone as addHostedZone,
   asyncDeleteHostedZone,
   asyncCheckHostedZone
 } from '~client/community/action-creators/dns-control'
@@ -34,11 +35,16 @@ const mapStateToProps = state => ({
   saving: DnsControlSelectors(state).dnsHostedZones().isSaving()
 })
 
-const mapActionsToProps = {
-  asyncAddHostedZone,
+const mapActionsToProps = (dispatch, { intl }) => ({
+  asyncAddHostedZone: (values) => {
+    return dispatch(addHostedZone(values))
+      .catch(err => {
+        dispatch(notify(dnsNotify.addHostedZoneFailure()))
+      })
+  },
   asyncCheckHostedZone,
   notify
-}
+})
 
 export default injectIntl(connect(mapStateToProps, mapActionsToProps)(
   reduxForm({ form: 'createDomainForm', fields, validate })(Page))


### PR DESCRIPTION
## Issues

- Add warning when domain could not be added by any reason. Closes #788

## How to test

- Ao tentar inserir um domínio já cadastrado, deve aparecer uma notificação informando o erro