### PR TITLE
Feature disable fields on pressure widget

### DIFF
--- a/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
@@ -88,11 +88,13 @@ export class Pressure extends Component {
       count_text: countText,
       pressure_subject: pressureSubject,
       pressure_body: pressureBody,
-      finish_message_type: finishMessageType
+      finish_message_type: finishMessageType,
+      disable_edit_field: disableEditField
     } = widget.settings || {
       main_color: '#f23392',
       title_text: 'Envie um e-mail para quem pode tomar essa decisão',
-      button_text: 'Enviar e-mail'
+      button_text: 'Enviar e-mail',
+      disable_edit_field: 'n'
     }
 
     return (
@@ -118,6 +120,7 @@ export class Pressure extends Component {
             </h2>
             <TargetList targets={::this.getTargetList() || []} />
             <PressureForm
+              disabled={disableEditField === 's'}
               widget={widget}
               buttonText={(saving && !editable ? 'Enviando...' : buttonText)}
               buttonColor={mainColor}

--- a/client/mobilizations/widgets/__plugins__/pressure/components/pressure-form/index.js
+++ b/client/mobilizations/widgets/__plugins__/pressure/components/pressure-form/index.js
@@ -74,7 +74,7 @@ class PressureForm extends Component {
   }
 
   render () {
-    const { buttonColor, buttonText, children, widget } = this.props
+    const { buttonColor, buttonText, children, widget, disabled } = this.props
     const { email, name, lastname, city, subject, body, errors } = this.state
     return (
       <form className='pressure-form' onSubmit={::this.handleSubmit}>
@@ -153,6 +153,7 @@ class PressureForm extends Component {
                 style={inputReset}
                 type='text'
                 value={subject}
+                disabled={disabled}
                 onChange={e => this.setState({ subject: e.target.value })}
               />
             </div>
@@ -166,6 +167,7 @@ class PressureForm extends Component {
                 className='col-12 mt1'
                 style={{...inputReset, height: '7rem'}}
                 value={body}
+                disabled={disabled}
                 onChange={e => this.setState({ body: e.target.value })}
               />
             </div>

--- a/routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.connected.js
+++ b/routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.connected.js
@@ -7,6 +7,10 @@ import { messagePressureTargetsRemoveAll } from '~client/utils/notifications'
 import Page from './page'
 
 const mapStateToProps = (state, props) => {
+  const { settings } = props.widget
+  const disable = settings && !settings.disable_edit_field ? 'n'
+    : settings.disable_edit_field
+
   return {
     initialValues: {
       ...props.widget.settings || {},
@@ -33,7 +37,7 @@ const validate = values => {
 export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(
   reduxForm({
     form: 'widgetsPressureSettingsEmailForm',
-    fields: ['pressure_subject', 'pressure_body', 'targets'],
+    fields: ['pressure_subject', 'pressure_body', 'targets', 'disable_edit_field'],
     validate
   })(Page)
 ))

--- a/routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.js
+++ b/routes/admin/authenticated/sidebar/widgets-pressure-settings/email/page.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import { FormattedMessage, intlShape } from 'react-intl'
 
 import * as os from '~client/utils/browser/os'
-import { FormGroup, ControlLabel, FormControl } from '~client/components/forms'
+import { FormGroup, ControlLabel, FormControl, RadioGroup, Radio } from '~client/components/forms'
 import { SettingsForm } from '~client/ux/components'
 import { InputTag } from '~client/mobilizations/widgets/components'
 import { Info } from '~client/components/notify'
@@ -44,7 +44,8 @@ class PressureSettingsEmailPage extends Component {
       fields: {
         pressure_subject: pressureSubject,
         pressure_body: pressureBody,
-        targets: targetsField
+        targets: targetsField,
+        disable_edit_field: disableEditField
       },
       intl,
       ...props
@@ -168,6 +169,18 @@ class PressureSettingsEmailPage extends Component {
             />
           </ControlLabel>
           <FormControl type='text' componentClass='textarea' rows='7' />
+        </FormGroup>
+        <FormGroup controlId='disable-edit-field-id' {...disableEditField}>
+          <ControlLabel>
+            <FormattedMessage
+              id='page--pressure-widget-email.form.disable-edit-field.label'
+              defaultMessage='Desabilitar edição de assuno e corpo do e-mail'
+            />
+          </ControlLabel>
+          <RadioGroup>
+            <Radio value='s'>Sim</Radio>
+            <Radio value='n'>Não</Radio>
+          </RadioGroup> 
         </FormGroup>
       </SettingsForm>
     )


### PR DESCRIPTION
## Issues

- Add option to disable subject and text from pressure widget #791

## How to test

1. Com o widget de pressão inserido em sua mobilização, vá em `Configurações > E-mail para alvo` e desabilite / habilite a opção `DESABILITAR EDIÇÃO DE ASSUNO E CORPO DO E-MAIL`
2. Deve ser desabilitado / habilitado para edição os campos `Assunto` e `Corpo do E-mail` na visão pública da sua mobilização

## Blocked by

- https://github.com/nossas/bonde-server/pull/353