### PR TITLE
Hotfix pressure and templates

### DIFF
--- a/routes/admin/authenticated/sidebar/templates-choose-custom/page.connected.js
+++ b/routes/admin/authenticated/sidebar/templates-choose-custom/page.connected.js
@@ -28,7 +28,7 @@ const mapActionsToProps = {
 
 const GraphPage = graphql(gql`
   query customTemplates($communityId: Int!) {
-    customTemplates (communityId: $communityId) {
+    customTemplates (ctxCommunityId: $communityId) {
       nodes {
         id,
         name,

--- a/routes/admin/authenticated/sidebar/templates-choose/page.connected.js
+++ b/routes/admin/authenticated/sidebar/templates-choose/page.connected.js
@@ -38,7 +38,7 @@ const mapActionsToProps = (dispatch, props) => ({
 
 const GraphPage = graphql(gql`
   query allTemplates($communityId: Int!) {
-    customTemplates (communityId: $communityId) {
+    customTemplates (ctxCommunityId: $communityId) {
       totalCount
     }
     globalTemplates {

--- a/routes/admin/authenticated/sidebar/widgets-pressure-settings/autofire/page.connected.js
+++ b/routes/admin/authenticated/sidebar/widgets-pressure-settings/autofire/page.connected.js
@@ -12,9 +12,9 @@ const mapStateToProps = (state, props) => {
 }
 
 export default connect(mapStateToProps)(
-  reduxForm({
+  injectIntl(reduxForm({
     form: 'formAutofireForm',
     fields,
     validate
-  })(injectIntl(Page))
-)
+  })(Page)
+))


### PR DESCRIPTION
# Issues

1. Fix query param on custom templates. Closes #796
2. TypeError: Cannot read property 'formatMessage' of undefined. Closes #795

## How to test

1. Acessar `/mobilizations/[:mobilization_id]/templates/choose` com uma mobilização vazia, deve abrir as opções de templates globais / customizados

2. Acessar a configuração `Mensagem de agradecimento` do widget de pressão, deve renderizar o formulário para preenchimento.

## Blocked by

https://github.com/nossas/bonde-server/pull/357