### PR TITLE
Add a cancel button to Widget/Content

### DIFF
--- a/client/mobilizations/widgets/__plugins__/content/components/action-button.js
+++ b/client/mobilizations/widgets/__plugins__/content/components/action-button.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import classnames from 'classnames'
 
-const ActionButton = ({ children, editing, setState, onClick, title, style, className, state }) => (
+const ActionButton = ({ children, editing, onChange, onClick, title, style, className, state }) => (
   <button
     className={classnames('btn bg-blacker rounded', className)}
-    onClick={() => onClick(state)}
+    onClick={() => onClick(state, onChange)}
     style={{
       position: 'relative',
       display: editing ? 'inline-block' : 'none',

--- a/client/mobilizations/widgets/__plugins__/content/components/editor-slate/index.js
+++ b/client/mobilizations/widgets/__plugins__/content/components/editor-slate/index.js
@@ -62,11 +62,36 @@ class EditorSlate extends Component {
     }
   }
 
+  handleCancelEditionMode (state, setState) {
+    const initialRaw = JSON.stringify(Raw.serialize(this.state.initialState))
+    const raw = JSON.stringify(Raw.serialize(state))
+    if (initialRaw !== raw) {
+      if (window.confirm(this.props.intl.formatMessage({
+        id: 'c--editor-slate.button-cancel.message',
+        defaultMessage: 'Deseja mesmo sair do modo edição? Suas alterações não serão salvas.'
+      }))) {
+        this.setState({ editing: false })
+        setState(this.state.initialState)
+      }
+    } else {
+      this.setState({ editing: false })
+    }
+  }
+
+  handleSave (state) {
+    this.setState({ initialState: state })
+    this.props.handleSave(state)
+  }
+
   render () {
-    const { handleSave, handleDelete, readOnly, toolbarStyles, contentStyles } = this.props
+    const { handleDelete, readOnly, toolbarStyles, contentStyles } = this.props
     return (
       <div className='widgets--content-plugin'>
-        <SlateEditor plugins={plugins} initialState={this.state.initialState} style={{ color: '#fff' }}>
+        <SlateEditor
+          plugins={plugins}
+          initialState={this.state.initialState}
+          style={{ color: '#fff' }}
+        >
           <SlateToolbar style={{
             ...styles.toolbar,
             display: this.state.editing ? 'block' : 'none',
@@ -107,37 +132,34 @@ class EditorSlate extends Component {
                 bottom: 0
               }}
               className='mt2'
-              onClick={() => {
-                handleDelete()
-              }}
+              onClick={handleDelete}
             >
               <i className='fa fa-trash' />
             </ActionButton>
             <ActionButton
               editing={this.state.editing}
               className='mt2 right-align'
-              onClick={state => {
-                this.setState({ editing: false, initialState: state })
-                handleSave(state)
-              }}
+              onClick={this.handleSave.bind(this)}
             >
               <FormattedMessage
                 id='c--editor-slate.button-save.text'
                 defaultMessage='Salvar'
               />
             </ActionButton>
+            <ActionButton
+              editing={this.state.editing}
+              className='mt2 right-align mx2'
+              onClick={this.handleCancelEditionMode.bind(this)}
+            >
+              <FormattedMessage
+                id='c--editor-slate.button-cancel.text'
+                defaultMessage='Cancelar'
+              />
+            </ActionButton>
           </FooterEditor>
           <Layer
             editing={this.state.editing}
-            onClick={(state, setState) => {
-              if (window.confirm(this.props.intl.formatMessage({
-                id: 'c--editor-slate.button-cancel.text',
-                defaultMessage: 'Deseja mesmo sair do modo edição? Suas alterações não serão salvas.'
-              }))) {
-                this.setState({ editing: false })
-                setState(this.state.initialState)
-              }
-            }}
+            onClick={this.handleCancelEditionMode.bind(this)}
           />
         </SlateEditor>
         {this.state.loading && <Loading />}

--- a/client/mobilizations/widgets/__plugins__/content/components/editor-slate/index.js
+++ b/client/mobilizations/widgets/__plugins__/content/components/editor-slate/index.js
@@ -118,6 +118,12 @@ class EditorSlate extends Component {
             onSelectionChange={() => {
               if (!readOnly) this.setState({ editing: true })
             }}
+            onKeyDown={(event, data, state) => {
+              if (data.isMod && data.key === 's') {
+                event.preventDefault()
+                this.handleSave(state)
+              }
+            }}
             className={!readOnly ? 'editable' : ''}
             readOnly={readOnly}
           />

--- a/client/mobilizations/widgets/__plugins__/content/components/editor-slate/index.js
+++ b/client/mobilizations/widgets/__plugins__/content/components/editor-slate/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { FormattedMessage } from 'react-intl'
+import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
 import { Raw, Plain } from 'slate'
 import {
   SlateEditor, SlateToolbar, SlateContent,
@@ -57,16 +57,16 @@ class EditorSlate extends Component {
     super(props)
     this.state = {
       editing: false,
-      loading: false
+      loading: false,
+      initialState: Raw.deserialize(JSON.parse(props.content), { terse: true })
     }
   }
 
   render () {
-    const { content, handleSave, handleDelete, readOnly, toolbarStyles, contentStyles } = this.props
-    const initialState = Raw.deserialize(JSON.parse(content), { terse: true })
+    const { handleSave, handleDelete, readOnly, toolbarStyles, contentStyles } = this.props
     return (
       <div className='widgets--content-plugin'>
-        <SlateEditor plugins={plugins} initialState={initialState} style={{ color: '#fff' }}>
+        <SlateEditor plugins={plugins} initialState={this.state.initialState} style={{ color: '#fff' }}>
           <SlateToolbar style={{
             ...styles.toolbar,
             display: this.state.editing ? 'block' : 'none',
@@ -117,7 +117,7 @@ class EditorSlate extends Component {
               editing={this.state.editing}
               className='mt2 right-align'
               onClick={state => {
-                this.setState({ editing: false })
+                this.setState({ editing: false, initialState: state })
                 handleSave(state)
               }}
             >
@@ -129,9 +129,14 @@ class EditorSlate extends Component {
           </FooterEditor>
           <Layer
             editing={this.state.editing}
-            onClick={state => {
-              this.setState({ editing: false })
-              handleSave(state)
+            onClick={(state, setState) => {
+              if (window.confirm(this.props.intl.formatMessage({
+                id: 'c--editor-slate.button-cancel.text',
+                defaultMessage: 'Deseja mesmo sair do modo edição? Suas alterações não serão salvas.'
+              }))) {
+                this.setState({ editing: false })
+                setState(this.state.initialState)
+              }
             }}
           />
         </SlateEditor>
@@ -139,6 +144,10 @@ class EditorSlate extends Component {
       </div>
     )
   }
+}
+
+EditorSlate.propTypes = {
+  intl: intlShape.isRequired
 }
 
 EditorSlate.defaultProps = {
@@ -149,4 +158,4 @@ export const createEditorContent = content => JSON.stringify(
   Raw.serialize(Plain.deserialize(content), { terse: true })
 )
 
-export default EditorSlate
+export default injectIntl(EditorSlate)

--- a/client/mobilizations/widgets/__plugins__/content/components/layer.js
+++ b/client/mobilizations/widgets/__plugins__/content/components/layer.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const Layer = ({ editing, onClick, state }) => (
+const Layer = ({ editing, onClick, state, onChange }) => (
   <div
     style={{
       display: editing ? 'block' : 'none',
@@ -12,7 +12,7 @@ const Layer = ({ editing, onClick, state }) => (
       backgroundColor: 'rgba(0,0,0,.3)',
       zIndex: 1
     }}
-    onClick={() => onClick(state)}
+    onClick={() => onClick(state, onChange)}
   />
 )
 

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -1148,7 +1148,8 @@ servidor-03.dominio.com`,
   // filepath: /client/mobilizations/widgets/__plugins__/content/components/editor-slate/index.js
   // routepath: /mobilizations/:mobilization_id/edit
   'c--editor-slate.button-save.text': 'Salvar',
-  'c--editor-slate.button-cancel.text': 'Deseja mesmo sair do modo edição? Suas alterações não serão salvas.',
+  'c--editor-slate.button-cancel.text': 'Cancelar',
+  'c--editor-slate.button-cancel.message': 'Deseja mesmo sair do modo edição? Suas alterações não serão salvas.',
 
   // page form widget fields
   // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/fields/page.js

--- a/intl/locale-data/pt-BR.js
+++ b/intl/locale-data/pt-BR.js
@@ -255,6 +255,7 @@ servidor-03.dominio.com`,
   // page community info
   // filepath: /routes/admin/authenticated/sidebar/community-settings/info/page.js
   // routepath: /community/info
+  'page--community-info.form.successMessage': 'Informações básicas inseridas com sucesso',
   'page--community-info.form.logo.label': 'Logo',
   'page--community-info.form.name.label': 'Nome',
   'page--community-info.form.name.placeholder': 'Insira o nome da sua comunidade',
@@ -1147,6 +1148,7 @@ servidor-03.dominio.com`,
   // filepath: /client/mobilizations/widgets/__plugins__/content/components/editor-slate/index.js
   // routepath: /mobilizations/:mobilization_id/edit
   'c--editor-slate.button-save.text': 'Salvar',
+  'c--editor-slate.button-cancel.text': 'Deseja mesmo sair do modo edição? Suas alterações não serão salvas.',
 
   // page form widget fields
   // filepath: /routes/admin/authenticated/sidebar/widgets-form-settings/fields/page.js


### PR DESCRIPTION
1. Levando em consideração a melhoria na usabilidade do usuário, qualquer forma de sair do modo edição, habilita uma mensagem de confirmação (`Deseja mesmo sair do modo edição? Suas alterações não serão salvas.`), essa mensagem deve aparecer, caso você possua uma alteração não salva no editor.

Formas de sair do modo edição:
- Clicando fora do editor
- Pressionando o botão `Cancelar`

2. Quando tiver salvando as alterações, o comportamento passa a ser apenas o de enviar as alterações para serem salvas na base de dados, diferente do comportamento antigo, que ao salvar saia automaticamente do modo edição.

Formas de salvar as alterações:
- Clicando no botão `Salvar`
- Pressionando `Ctrl+S`

