### PR TITLE
Hotfix  to login autentication

### DIFF
--- a/packages/bonde-admin/routes-v1/subroutes/logged.js
+++ b/packages/bonde-admin/routes-v1/subroutes/logged.js
@@ -15,6 +15,12 @@ import SidebarRoute from './sidebar'
 import PrivateRoute from '~root/routes-v1/private-route'
 
 class Logged extends React.Component {
+  componentDidMount () {
+    if (this.props.user) {
+      this.props.load(this.props.user)
+    }
+  }
+
   componentWillReceiveProps (nextProps) {
     if (!this.props.user && nextProps.user) {
       this.props.load(nextProps.user)

--- a/packages/bonde-admin/routes/admin/authenticated/external/community-list/page.connected.js
+++ b/packages/bonde-admin/routes/admin/authenticated/external/community-list/page.connected.js
@@ -2,17 +2,21 @@
 // @route /community
 //
 import { connect } from 'react-redux'
-
+import AuthSelectors from '~client/account/redux/selectors'
 import * as CommunityActions from '~client/community/action-creators'
 import * as CommunitySelectors from '~client/community/selectors'
 
 import Page from './page'
 
-const mapStateToProps = state => ({
-  user: state.auth.user,
-  isLoading: CommunitySelectors.isLoading(state),
-  isLoaded: CommunitySelectors.isLoaded(state),
-  communities: CommunitySelectors.getList(state)
-})
+const mapStateToProps = state => {
+  const user = AuthSelectors(state).getUser()
+  const loading = CommunitySelectors.isLoading(state) || !user
+  return {
+    user,
+    isLoading: loading,
+    isLoaded: CommunitySelectors.isLoaded(state),
+    communities: CommunitySelectors.getList(state)
+  }
+}
 
 export default connect(mapStateToProps, CommunityActions)(Page)


### PR DESCRIPTION
1. O problema comentado pelo @lpirola foi corrigido, como eu imaginava tinha haver com o ponto de carregamento do usuário, que só estava sendo feito no `componentWillReceiveProps` esse metodo não é chamado no momento de montagem do componente, por esse motivo também é necessário fazer o carregamento no `componentDidMount`.

2. Outro ponto que achei melhor adicionar, é a renderização de sub-paginas logadas serem executadas somente quando usuário estiver carregado, isso gera um loading inifinito (gerava antes da mudança citada acima, mas achei melhor manter assim) obrigando o usuário a recarregar página, fazendo com que a aplicação refaça o processo de carregar usuário e verificar acesso na API.