### PR TITLE
fix(domains): Force public view redirect to url with www

### DIFF
--- a/packages/bonde-public/pages/index.js
+++ b/packages/bonde-public/pages/index.js
@@ -22,12 +22,23 @@ import {
 import styles from './../webviewer/main.dba55199cd8fb7024923.css'
 
 class Page extends React.Component {
-  static async getInitialProps ({ store, req }) {
+  static async getInitialProps ({ store, req, res }) {
     const { dispatch, getState } = store
     const host = getState().sourceRequest.host
+    const protocol = getState().sourceRequest.protocol
     const appDomain = process.env.APP_DOMAIN || 'bonde.devel'
 
     if (host) {
+      if (res) { // force host to be with www
+        if (!host.startsWith("www", 0)) {
+          res.writeHead(302, {
+            Location: `${protocol}://www.${host}`
+          })
+          res.end()
+        }
+      }
+      // return {}
+
       const {
         asyncFilterMobilization,
         asyncFilterBlock,


### PR DESCRIPTION
Problema:

Atualmente as páginas hospedadas pelo bonde-cache são automaticamente direcionadas para sua url com www e com a desativação do bonde-cache, essa responsabilidade precisa ser assumida por uma parte da aplicação.

Solução:

No bonde-public, caso não seja encontrado www na URL forçar uma redirect com 302 para a mesma URL adicionando o www no início mas obedecendo o protocolo.