### PR TITLE
Hotfix reset password fidelity

### DIFF
--- a/packages/bonde-admin-canary/public/locales/pt-BR/auth.json
+++ b/packages/bonde-admin-canary/public/locales/pt-BR/auth.json
@@ -55,15 +55,16 @@
       "label": "Email",
       "placeholder": "seuemail@exemplo.com",
       "isEmpty": "Preenchimento obrigatório",
-      "isEmail": "E-mail inválido",
-      "notFound": "Não encontramos seu endereço de e-mail"
+      "isEmail": "Opa, confira seu email",
+      "notFound": "Tem algo estranho"
     },
     "goback": "Voltar",
     "submit": "Recuperar senha",
     "successfully": {
       "title": "Link enviado!",
       "checkEmail": "Agora é só conferir seu e-mail e clicar no link que a gente enviou.",
-      "checkSpam": "Se o e-mail não chegar em alguns minutos, confira sua caixa de spam que ele pode estar lá."
+      "checkSpam": "Se o e-mail não chegar em alguns minutos, confira sua caixa de spam que ele pode estar lá.",
+      "checkExpiry": "Em 48 horas o link irá expirar e será preciso inserir o e-mail de novo."
     }
   },
   "resetPassword": {

--- a/packages/bonde-admin-canary/public/locales/pt-BR/auth.json
+++ b/packages/bonde-admin-canary/public/locales/pt-BR/auth.json
@@ -54,9 +54,8 @@
     "email": {
       "label": "Email",
       "placeholder": "seuemail@exemplo.com",
-      "isEmpty": "Preenchimento obrigatório",
       "isEmail": "Opa, confira seu email",
-      "notFound": "Tem algo estranho"
+      "notFound": "Ops! E-mail não encontrado"
     },
     "goback": "Voltar",
     "submit": "Recuperar senha",

--- a/packages/bonde-admin-canary/public/locales/pt-BR/auth.json
+++ b/packages/bonde-admin-canary/public/locales/pt-BR/auth.json
@@ -88,6 +88,6 @@
       "goBackLogin": "Voltar para o login"
     },
     "checkingToken": "Verificando o link",
-    "success": "Tudo certo! Sua senha já foi atualizada, BONDE que segue."
+    "success": "Tudo certo, {{user.name}}! Sua senha já foi atualizada, BONDE que segue."
   }
 }

--- a/packages/bonde-admin-canary/src/components/Form/Form.js
+++ b/packages/bonde-admin-canary/src/components/Form/Form.js
@@ -15,4 +15,4 @@ const Form = ({ children, error, handleSubmit }) => {
 
 }
 
-export default reduxForm({ form: 'authLogin' })(Form)
+export default reduxForm({ form: 'components/Form' })(Form)

--- a/packages/bonde-admin-canary/src/components/Form/SubmitButton.js
+++ b/packages/bonde-admin-canary/src/components/Form/SubmitButton.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Button } from 'bonde-styleguide'
+import { isValid, isPristine } from 'redux-form'
+import { connect } from 'services/redux'
+
+const mapStateToProps = state => ({
+  valid: isValid('components/Form')(state),
+  pristine: isPristine('components/Form')(state)
+})
+
+export default connect(mapStateToProps)(
+  ({ children, valid, pristine }) => (
+    <Button type='submit' disabled={pristine || !valid}>
+      {children}
+    </Button>
+  )
+)

--- a/packages/bonde-admin-canary/src/components/Form/index.js
+++ b/packages/bonde-admin-canary/src/components/Form/index.js
@@ -1,3 +1,4 @@
 export { default as Form } from './Form'
 export { default as FormGraphQL } from './FormGraphQL'
 export { Field, SubmissionError } from 'redux-form'
+export { default as SubmitButton } from './SubmitButton'

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
@@ -53,7 +53,7 @@ export default ({ onSuccess }) => (
             isEmail(t('forgetPassword.email.isEmail'))
           ]}
         />
-        <Flexbox horizontal>
+        <Flexbox padding={{ top: 25 }} horizontal>
           <ButtonLink
             to='/auth/login'
             title={t('forgetPassword.goback')}

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
@@ -9,7 +9,7 @@ import {
 } from 'bonde-styleguide'
 import { FormGraphQL, Field } from 'components/Form'
 import { ButtonLink } from 'components/Link'
-import { isEmail, required } from 'services/validations'
+import { isEmail } from 'services/validations'
 import RequestTokenMutation from './requestResetPasswordToken.graphql'
 
 export default ({ onSuccess }) => (
@@ -49,7 +49,6 @@ export default ({ onSuccess }) => (
           component={FormField}
           inputComponent={Input}
           validate={[
-            required(t('forgetPassword.email.isEmpty')),
             isEmail(t('forgetPassword.email.isEmail'))
           ]}
         />

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
@@ -16,8 +16,8 @@ export default ({ onSuccess }) => (
   <I18n ns='auth'>
   {(t, { i18n }) => (
     <Flexbox>
-      <Title.H2 margin={{ bottom: 20 }}>{t('forgetPassword.title')}</Title.H2>
-      <Title.H4 margin={{ bottom: 25 }}>{t('forgetPassword.description')}</Title.H4>
+      <Title.H2 margin={{ bottom: 18 }}>{t('forgetPassword.title')}</Title.H2>
+      <Title.H4 margin={{ bottom: 30 }}>{t('forgetPassword.description')}</Title.H4>
       <FormGraphQL
         mutation={RequestTokenMutation}
         onSubmit={({ email }, mutation) => {

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { I18n } from 'react-i18next'
 import {
-  Button,
   Flexbox,
   FormField,
   Input,

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/RequestTokenForm.js
@@ -7,7 +7,7 @@ import {
   Input,
   Title
 } from 'bonde-styleguide'
-import { FormGraphQL, Field } from 'components/Form'
+import { FormGraphQL, Field, SubmitButton } from 'components/Form'
 import { ButtonLink } from 'components/Link'
 import { isEmail } from 'services/validations'
 import RequestTokenMutation from './requestResetPasswordToken.graphql'
@@ -59,9 +59,9 @@ export default ({ onSuccess }) => (
           >
             {t('forgetPassword.goback')}
           </ButtonLink>
-          <Button type='submit'>
+          <SubmitButton>
             {t('forgetPassword.submit')}
-          </Button>
+          </SubmitButton>
         </Flexbox>
       </FormGraphQL>
     </Flexbox>

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/SubmittedSuccessfully.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ForgetPassword/SubmittedSuccessfully.js
@@ -17,9 +17,18 @@ export default () => (
           <div>
             <IconColorful name='mobilization' size={80} />
           </div>
-          <Title.H2 margin={{ y: 20 }}>{t('forgetPassword.successfully.title')}</Title.H2>
-          <Title.H4 margin={spacing}>{t('forgetPassword.successfully.checkEmail')}</Title.H4>
-          <Title.H4 margin={spacing}>{t('forgetPassword.successfully.checkSpam')}</Title.H4>
+          <Title.H2 margin={{ y: 20 }}>
+            {t('forgetPassword.successfully.title')}
+          </Title.H2>
+          <Title.H4 margin={spacing}>
+            {t('forgetPassword.successfully.checkEmail')}
+          </Title.H4>
+          <Title.H4 margin={spacing}>
+            {t('forgetPassword.successfully.checkSpam')}
+          </Title.H4>
+          <Title.H4 margin={spacing}>
+            {t('forgetPassword.successfully.checkExpiry')}
+          </Title.H4>
           <ButtonLink to='/auth/login'>{t('forgetPassword.goback')}</ButtonLink>
         </Flexbox>
       )

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/Login/Page.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/Login/Page.js
@@ -66,7 +66,7 @@ const AuthLogin = ({ t }) => (
           <Checkbox>{t('links.stayConnected')}</Checkbox>
         </Flexbox>
       */}
-      <Flexbox horizontal end>
+      <Flexbox horizontal>
         <ButtonLink
           to='/auth/forget-password'
           title={t('links.forgePassword')}

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Flexbox2 as Flexbox, Title } from 'bonde-styleguide'
+import { Flexbox2 as Flexbox, Title } from 'bonde-styleguide'
 import { Field, FormGraphQL, SubmitButton } from 'components/Form'
 import { ButtonLink } from 'components/Link'
 import { required, min } from 'services/validations'

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button, Flexbox2 as Flexbox, Title } from 'bonde-styleguide'
-import { Field, FormGraphQL } from 'components/Form'
+import { Field, FormGraphQL, SubmitButton } from 'components/Form'
 import { ButtonLink } from 'components/Link'
 import { required, min } from 'services/validations'
 import { PasswordField } from '../../components'
@@ -34,7 +34,7 @@ export default ({ t, token, handleSuccess }) => (
       />
       <Flexbox horizontal spacing='between'>
         <ButtonLink to='/auth/login'>{t('resetPassword.form.cancel')}</ButtonLink>
-        <Button type='submit'>{t('resetPassword.form.submit')}</Button>
+        <SubmitButton>{t('resetPassword.form.submit')}</SubmitButton>
       </Flexbox>
     </FormGraphQL>
   </Flexbox>

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
@@ -8,8 +8,8 @@ import resetPassword from './resetPassword.graphql'
 
 export default ({ t, token, handleSuccess }) => (
   <Flexbox vertical>
-    <Title.H2 margin={{ bottom: 20 }}>{t('resetPassword.form.title')}</Title.H2>
-    <Title.H4 margin={{ bottom: 15 }}>{t('resetPassword.form.subtitle')}</Title.H4>
+    <Title.H2 margin={{ bottom: 18 }}>{t('resetPassword.form.title')}</Title.H2>
+    <Title.H4 margin={{ bottom: 30 }}>{t('resetPassword.form.subtitle')}</Title.H4>
     <FormGraphQL
       mutation={resetPassword}
       onSubmit={(values, mutation) => {
@@ -32,7 +32,7 @@ export default ({ t, token, handleSuccess }) => (
           min(6, t('resetPassword.fields.password.min6'))
         ]}
       />
-      <Flexbox horizontal spacing='between'>
+      <Flexbox padding={{ top: 25 }} horizontal spacing='between'>
         <ButtonLink to='/auth/login'>{t('resetPassword.form.cancel')}</ButtonLink>
         <SubmitButton>{t('resetPassword.form.submit')}</SubmitButton>
       </Flexbox>

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/resetPassword.graphql.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/resetPassword.graphql.js
@@ -9,6 +9,9 @@ mutation ResetPassword (
     newPassword:$newPassword,
     token:$token
   }) {
-    jwtToken
+    changePasswordField {
+      userFirstName,
+      token
+    }
   }
 }`

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
@@ -27,11 +27,14 @@ export default ({ match }) => (
             t={t}
             token={token}
             handleSuccess={({ data }) => {
+              const { changePasswordField } = data.resetPasswordChangePassword
+              const user = { name: changePasswordField.userFirstName }
+              
               AuthAPI.login({
-                jwtToken: data.resetPasswordChangePassword.jwtToken
+                jwtToken: changePasswordField.token
               })
               .then(() => {
-                notify(t('resetPassword.success'))
+                notify(t('resetPassword.success', { user }))
               })
             }}
           />

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/components/PasswordField.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/components/PasswordField.js
@@ -14,7 +14,7 @@ class PasswordField extends React.Component {
       <React.Fragment>
         <FormField
           type={!showPassword ? 'password' : 'text'}
-          placeholder='******'
+          placeholder='&#9679;&#9679;&#9679;&#9679;&#9679;'
           inputComponent={Input}
           {...props}
         />


### PR DESCRIPTION
Esse PR serve para garantir fidelidade do fluxo de recuperar senha.

refs.:
https://www.pivotaltracker.com/story/show/158827149
https://www.pivotaltracker.com/story/show/158827151 

dependencias:
https://github.com/nossas/bonde-server/pull/505

## Novos components

- **SubmitButton**
Como uma demanda de UX surgiu um novo componente no nosso `components/Form`, chamado de `SubmitButton`, esse botão implementa um `bonde-styleguide/Button` e está habilitado apenas quando o formulário foi manipulado e é valido.