### PR TITLE
Adiciona documento para contribuidores

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,30 @@
-# Código de Conduta para Colaboradores
+# Contribuindo
 
-## Nossa promessa
+Ao contribuir com este projeto, por favor, discuta primeiro a mudança que
+deseja fazer via issue com os mantenedores do projeto antes de fazer uma
+alteração.
+
+Por favor, note que temos um código de conduto, você deve segui-lo em todas as
+suas interações com o projeto.
+
+## Enviando sua colaboração (Pull request)
+
+1. Atualize o README.md com detalhes das mudanças na interface, isso inclui
+   novas variáveis de ambiente, portas expostas, arquivos utéis e parâmetros do
+   container.
+2. Aumente os números de versão em quaisquer arquivos de exemplos e o README.md
+   para a nova versão que está solicitação de extração representaria. O esquema
+   de versionamento que usamos é [SemVer](https://semver.org/)
+3. Use [Gitflow
+   Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)
+   no fluxo de alteração do código fonte.
+4. Você pode mesclar o pull request, uma vez que você tenha a assinatura de
+   dois outros desenvolvedores, ou se você não tiver permissão para fazer isso,
+   você pode solicitar o segundo revisor para mesclar isso para você.
+
+## Código de Conduta para Colaboradores
+
+### Nossa promessa
 
 Com o interesse de fomentar uma comunidade aberta e acolhedora,
 nós, como colaboradores e administradores deste projeto, comprometemo-nos
@@ -10,7 +34,7 @@ etnia, gênero, idade, identidade ou expressão de gênero, identidade
 ou orientação sexual, nacionalidade, nível de experiência, porte físico,
 raça ou religião.
 
-## Nossos padrões
+### Nossos padrões
 
 Exemplos de comportamentos que contribuem a criar um ambiente positivo incluem:
 
@@ -31,7 +55,7 @@ exemplo, um endereço eletrônico ou residencial
 * Qualquer outra forma de conduta que pode ser razoavelmente considerada
 inapropriada num ambiente profissional
 
-## Nossas responsibilidades
+### Nossas responsibilidades
 
 Os administradores do projeto são responsáveis por esclarecer os padrões de
 comportamento e deverão tomar ação corretiva apropriada e justa em resposta
@@ -44,7 +68,7 @@ acordo com este Código de Conduta, bem como banir temporariamente ou
 permanentemente qualquer colaborador por qualquer outro comportamento
 que se considere impróprio, perigoso, ofensivo ou problemático.
 
-## Escopo
+### Escopo
 
 Este Código de Conduta aplica-se dentro dos espaços do projeto ou
 qualquer espaço público onde alguém represente o mesmo ou a sua
@@ -54,7 +78,7 @@ mídia social oficial, ou agir como um representante designado num evento
 online ou offline. A representação de um projeto pode ser ainda definida e
 esclarecida pelos administradores do projeto.
 
-## Aplicação
+### Aplicação
 
 Comportamento abusivo, de assédio ou de outros tipos pode ser
 comunicado contatando a equipe do projeto [INSIRA O ENDEREÇO
@@ -68,7 +92,7 @@ Administradores do projeto que não sigam ou não mantenham o Código
 de Conduta em boa fé podem enfrentar repercussões temporárias ou permanentes
 determinadas por outros membros da liderança do projeto.
 
-## Atribuição
+### Atribuição
 
 Este Código de Conduta é adaptado do [Contributor
 Covenant](https://www.contributor-covenant.org), versão 1.4, disponível em

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Código de Conduta para Colaboradores
+
+## Nossa promessa
+
+Com o interesse de fomentar uma comunidade aberta e acolhedora,
+nós, como colaboradores e administradores deste projeto, comprometemo-nos
+a fazer a participação deste projeto uma experiência livre de assédio
+para todos, independentemente da aparência pessoal, deficiência,
+etnia, gênero, idade, identidade ou expressão de gênero, identidade
+ou orientação sexual, nacionalidade, nível de experiência, porte físico,
+raça ou religião.
+
+## Nossos padrões
+
+Exemplos de comportamentos que contribuem a criar um ambiente positivo incluem:
+
+* Usar linguagem acolhedora e inclusiva
+* Respeitar pontos de vista e experiências diferentes
+* Aceitar crítica construtiva com graça
+* Focar no que é melhor para a comunidade
+* Mostrar empatia com outros membros da comunidade
+
+Exemplos de comportamentos inaceitáveis por parte dos participantes incluem:
+
+* Uso de linguagem ou imagens sexuais e atenção ou avanço sexual indesejada
+* Comentários insultuosos e/ou depreciativos e ataques pessoais ou políticos
+(*Trolling*)
+* Assédio público ou privado
+* Publicar informação pessoal de outros sem permissão explícita, como, por
+exemplo, um endereço eletrônico ou residencial
+* Qualquer outra forma de conduta que pode ser razoavelmente considerada
+inapropriada num ambiente profissional
+
+## Nossas responsibilidades
+
+Os administradores do projeto são responsáveis por esclarecer os padrões de
+comportamento e deverão tomar ação corretiva apropriada e justa em resposta
+a qualquer instância de comportamento inaceitável.
+
+Os administradores do projeto têm o direito e a responsabilidade de
+remover, editar ou rejeitar comentários, commits, código, edições
+na wiki, erros ou outras formas de contribuição que não estejam de
+acordo com este Código de Conduta, bem como banir temporariamente ou
+permanentemente qualquer colaborador por qualquer outro comportamento
+que se considere impróprio, perigoso, ofensivo ou problemático.
+
+## Escopo
+
+Este Código de Conduta aplica-se dentro dos espaços do projeto ou
+qualquer espaço público onde alguém represente o mesmo ou a sua
+comunidade. Exemplos de representação do projeto ou comunidade incluem
+usar um endereço de email oficial do projeto, postar por uma conta de
+mídia social oficial, ou agir como um representante designado num evento
+online ou offline. A representação de um projeto pode ser ainda definida e
+esclarecida pelos administradores do projeto.
+
+## Aplicação
+
+Comportamento abusivo, de assédio ou de outros tipos pode ser
+comunicado contatando a equipe do projeto [INSIRA O ENDEREÇO
+DE EMAIL]. Todas as queixas serão revistas e investigadas e
+resultarão numa resposta necessária e apropriada à situação.
+A equipe é obrigada a manter a confidencialidade em relação
+ao elemento que reportou o incidente. Demais detalhes de
+políticas de aplicação podem ser postadas separadamente.
+
+Administradores do projeto que não sigam ou não mantenham o Código
+de Conduta em boa fé podem enfrentar repercussões temporárias ou permanentes
+determinadas por outros membros da liderança do projeto.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor
+Covenant](https://www.contributor-covenant.org), versão 1.4, disponível em
+https://www.contributor-covenant.org/pt-br/version/1/4/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Ao contribuir com este projeto, por favor, discuta primeiro a mudança que
 deseja fazer via issue com os mantenedores do projeto antes de fazer uma
 alteração.
 
-Por favor, note que temos um código de conduto, você deve segui-lo em todas as
+Por favor, note que temos um código de conduta, você deve segui-lo em todas as
 suas interações com o projeto.
 
 ## Enviando sua colaboração (Pull request)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ export DSN_DEST=postgres://postgres:3x4mpl3@localhost:5432/bonde
 ```
 
 ## Links
+- [How to contribute](CONTRIBUTING.md)
 - [Pivotal Tracker](https://www.pivotaltracker.com/n/projects/888220)
 - [Invision](https://projects.invisionapp.com/share/763UO3YDT#/screens)
 - [Zeplin](https://app.zeplin.io/project.html#pid=55d1d57e14a5317a0e909551)


### PR DESCRIPTION
Na busca de organizar e documentar o bonde para torná-lo um projeto open-source de fato, estou adicionando um documento de contribuição, que explica o processo de abertura de uma contribuição, através de um pull-request e explicita um código de conduta para contribuidores do projeto.