### PR TITLE
[pt-br] Correção no formulário de configurações da comunidade

### DIFF
--- a/packages/bonde-admin/client/community/reducers/communities.js
+++ b/packages/bonde-admin/client/community/reducers/communities.js
@@ -1,4 +1,4 @@
-import reactCookie from 'react-cookie'
+import cookie from 'react-cookie'
 import * as t from '../action-types'
 
 // Dependency module
@@ -40,15 +40,16 @@ export default (state = initialState, action = {}) => {
         data: [...state.data, action.community]
       }
     case t.EDIT:
-      // update community in cache
-      reactCookie.save('community', {
-        community: {
-          list: {
-            currentId: action.community.id,
-            data: [action.community]
-          }
+      // state saved on storages to hydrate
+      const hydrateState = {
+        list: {
+          currentId: action.community.id,
+          data: [action.community]
         }
-      })
+      }
+      window.localStorage.setItem('community', JSON.stringify(hydrateState))
+      cookie.save('community', hydrateState)
+
       return {
         ...state,
         data: state.data.map(


### PR DESCRIPTION
## O problema

Após alterar os dados de recebedor na aba Dados Bancarios, e atualizar a página (Ctrl + R) nota-se que os dados não estão atualizados.

## Solução

Os dados de comunidade são persistidos no cookie da aplicação, enquanto o estado inicial do redux re-hidrata o estado a partir do localStorage, isso significa que nenhum formulário do módulo de configurações da comunidade estava funcionando corretamente. Adicionei as informações atualizadas no localStorage para resolver o problema pontualmente, visto que está aplicação está sendo mantida apenas para correção de bugs, não me preocupei em aprofundar nessa funcionalidade de persistência dos dados, pois ela irá mudar na versão canary. 