### PR TITLE
[pt-br] Correção no formulário de configurações no widget de doação

### DIFF
--- a/packages/bonde-admin/client/mobrender/widgets/donations/component.js
+++ b/packages/bonde-admin/client/mobrender/widgets/donations/component.js
@@ -55,7 +55,7 @@ const DonationSettingsPage = props => {
         return asyncWidgetUpdate({
           ...widget,
           settings: { ...settings, ...values },
-          goal: String(values.goal).replace(/,/g, '.')
+          goal: values.goal && String(values.goal).replace(/,/g, '.')
         })
       }}
       successMessage={


### PR DESCRIPTION
## O problema

Erro na submissão do formulário quando o campo **Meta da campanha**, não era preenchido.

## Solução
O problema ocorria pois existe um parse para texto do valor de **Meta da campanha** e quando o valor não era preenchido esse parse transformava `undefined` em `"undefined"`, adicionado uma condição de valor preenchido antes da realização do parse e submissão do formulário.