### PR TITLE
[Feature][pt-br] Move plugin de conteúdo

### DIFF
--- a/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/index.js
+++ b/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/index.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Editor from './reboo-editor'
+
+if (require('exenv').canUseDOM) require('./index.scss')
+
+class EditorNew extends React.Component {
+
+  render () {
+    const { mobilization, widget: { settings } } = this.props
+    const { body_font: bodyFont } = mobilization
+
+    const theme = (
+      mobilization && mobilization.color_scheme
+        ? mobilization.color_scheme.replace('-scheme', '')
+        : null
+    )
+
+    let value
+    try {
+      value = JSON.parse(settings.content)
+    } catch (e) {
+      value = settings.content
+    }
+
+    return (
+      <div className='widgets--content-plugin widget editor-new' style={{ fontFamily: bodyFont }}>
+        <Editor value={value} theme={theme} />
+      </div>
+    )
+  }
+}
+
+EditorNew.propTypes = {
+  mobilization: PropTypes.object.isRequired,
+  widget: PropTypes.object.isRequired
+}
+
+export default EditorNew

--- a/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/index.js
+++ b/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/index.js
@@ -7,7 +7,7 @@ if (require('exenv').canUseDOM) require('./index.scss')
 class EditorNew extends React.Component {
 
   render () {
-    const { mobilization, widget: { settings } } = this.props
+    const { decorator, mobilization, widget: { settings } } = this.props
     const { body_font: bodyFont } = mobilization
 
     const theme = (
@@ -25,7 +25,7 @@ class EditorNew extends React.Component {
 
     return (
       <div className='widgets--content-plugin widget editor-new' style={{ fontFamily: bodyFont }}>
-        <Editor value={value} theme={theme} />
+        <Editor value={value} theme={theme} decorator={decorator} />
       </div>
     )
   }
@@ -33,7 +33,8 @@ class EditorNew extends React.Component {
 
 EditorNew.propTypes = {
   mobilization: PropTypes.object.isRequired,
-  widget: PropTypes.object.isRequired
+  widget: PropTypes.object.isRequired,
+  decorator: PropTypes.object.isRequired
 }
 
 export default EditorNew

--- a/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/index.scss
+++ b/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/index.scss
@@ -1,0 +1,10 @@
+.content-new-editor {
+  h1, h2, h3, h4, h5, h6 { font-weight: bold; }
+  a { text-decoration: none; }
+  h1 { font-size: 5rem; }
+  h2 { font-size: 3rem; }
+  h3 { font-size: 2rem; }
+  h4 { font-size: 1.5rem; }
+  h5 { font-size: 1rem; }
+  h6 { font-size: .5rem; }
+}

--- a/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/reboo-editor.js
+++ b/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/reboo-editor.js
@@ -7,8 +7,6 @@ import {
   convertFromHTML,
   convertFromRaw
 } from 'draft-js'
-// TODO: Remove this dependencies
-import { decorator } from '@/components/editor-draft-js/Toolbar'
 
 
 class RebooEditor extends React.Component {
@@ -25,7 +23,7 @@ class RebooEditor extends React.Component {
       throw new Error('Value invalid')
     }
 
-    const editorState = EditorState.createWithContent(contentState, decorator)
+    const editorState = EditorState.createWithContent(contentState, props.decorator)
 
     this.state = { editorState }
   }
@@ -46,7 +44,8 @@ class RebooEditor extends React.Component {
 }
 
 RebooEditor.propTypes = {
-  value: PropTypes.any
+  value: PropTypes.any,
+  decorator: PropTypes.object.isRequired
 }
 
 export default RebooEditor

--- a/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/reboo-editor.js
+++ b/packages/bonde-admin/src/1corelib/plugins/content/components/draft-editor/reboo-editor.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  Editor,
+  EditorState,
+  ContentState,
+  convertFromHTML,
+  convertFromRaw
+} from 'draft-js'
+// TODO: Remove this dependencies
+import { decorator } from '@/components/editor-draft-js/Toolbar'
+
+
+class RebooEditor extends React.Component {
+  constructor (props) {
+    super(props)
+
+    let contentState
+    if (typeof this.props.value === 'string') {
+      // initialValue is a string with syntax HTML, we need transform in contentState
+      contentState = ContentState.createFromBlockArray(convertFromHTML(this.props.value))
+    } else if (typeof this.props.value === 'object') {
+      contentState = convertFromRaw(this.props.value)
+    } else {
+      throw new Error('Value invalid')
+    }
+
+    const editorState = EditorState.createWithContent(contentState, decorator)
+
+    this.state = { editorState }
+  }
+
+  render () {
+    return (
+      <div className='reboo-editor'>
+        <div className='editor'>
+          <div>
+            <Editor ref='editor' readOnly editorState={this.state.editorState} />
+            <div style={{ 'clear': 'both' }} />
+          </div>
+        </div>
+
+      </div>
+    )
+  }
+}
+
+RebooEditor.propTypes = {
+  value: PropTypes.any
+}
+
+export default RebooEditor

--- a/packages/bonde-admin/src/1corelib/plugins/content/components/index.js
+++ b/packages/bonde-admin/src/1corelib/plugins/content/components/index.js
@@ -1,0 +1,2 @@
+export { default as DraftEditor } from './draft-editor'
+export { default as SlateEditor } from './slate-editor'

--- a/packages/bonde-admin/src/1corelib/plugins/content/components/slate-editor/index.js
+++ b/packages/bonde-admin/src/1corelib/plugins/content/components/slate-editor/index.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import { injectIntl, intlShape } from 'react-intl'
+import { SlateEditor, SlateContent } from 'slate-editor'
+import { BoldPlugin } from '@slate-editor/bold-plugin'
+import { ItalicPlugin } from '@slate-editor/italic-plugin'
+import { UnderlinePlugin } from '@slate-editor/underline-plugin'
+import { StrikethroughPlugin } from '@slate-editor/strikethrough-plugin'
+import { AlignmentPlugin } from '@slate-editor/alignment-plugin'
+import { LinkPlugin } from '@slate-editor/link-plugin'
+import { ListPlugin } from '@slate-editor/list-plugin'
+import { FontFamilyPlugin } from '@slate-editor/font-family-plugin'
+import { FontSizePlugin } from '@slate-editor/font-size-plugin'
+import { ImagePlugin } from '@slate-editor/image-plugin'
+import { ColorPlugin } from '@slate-editor/color-plugin'
+import { GridPlugin } from '@slate-editor/grid-plugin'
+import { EmbedPlugin } from '@slate-editor/embed-plugin'
+
+if (require('exenv').canUseDOM) require('./index.scss')
+
+const fontSizePluginOptions = { initialFontSize: 16 }
+
+const plugins = [
+  AlignmentPlugin(),
+  BoldPlugin(),
+  ColorPlugin(),
+  EmbedPlugin(),
+  FontFamilyPlugin(),
+  FontSizePlugin(fontSizePluginOptions),
+  GridPlugin(),
+  ImagePlugin(),
+  ItalicPlugin(),
+  LinkPlugin(),
+  ListPlugin(),
+  StrikethroughPlugin(),
+  UnderlinePlugin()
+]
+
+class EditorSlate extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      initialState: JSON.parse(props.content)
+    }
+  }
+
+  render () {
+    const { readOnly, contentStyles } = this.props
+    return (
+      <div className='widgets--content-plugin'>
+        <SlateEditor
+          plugins={plugins}
+          initialState={this.state.initialState}
+          style={{ color: '#fff' }}
+        >
+          <SlateContent
+            wrapperStyle={{ position: 'relative', zIndex: 'inherit' }}
+            style={{ minHeight: 150, ...contentStyles }}
+            readOnly={readOnly}
+          />
+        </SlateEditor>
+      </div>
+    )
+  }
+}
+
+EditorSlate.propTypes = {
+  intl: intlShape.isRequired
+}
+
+export default injectIntl(EditorSlate)

--- a/packages/bonde-admin/src/1corelib/plugins/content/components/slate-editor/index.scss
+++ b/packages/bonde-admin/src/1corelib/plugins/content/components/slate-editor/index.scss
@@ -1,0 +1,38 @@
+.editor--content > div {
+  min-height: 370px;
+}
+
+.editor--toolbar {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+.editor--toolbar > * {
+  display: inline-block;
+}
+.editor--toolbar .btn, .editor--toolbar .select, .editor--toolbar .input {
+  min-height: 50px;
+  background: none;
+  border: none;
+}
+.editor--toolbar .select, .editor--toolbar .input {
+  border: 1px solid #c7c7c7!important;
+}
+.editor--toolbar .select {
+  max-width: 200px;
+}
+.editor--toolbar .input {
+  max-width: 100px;
+}
+
+.editor--content.editable table {
+  border: 1px solid black;
+  border-collapse: collapse;
+}
+
+.editor--content.editable table > tbody > tr {
+  border-top: 1px solid black;
+  border-bottom: 1px solid black;
+}
+
+.editor--content.editable table > tbody >tr > td {
+  border-right: 1px solid black;
+}

--- a/packages/bonde-admin/src/1corelib/plugins/content/index.js
+++ b/packages/bonde-admin/src/1corelib/plugins/content/index.js
@@ -1,0 +1,1 @@
+export { default as ContentPlugin } from './plugin'

--- a/packages/bonde-admin/src/1corelib/plugins/content/plugin.js
+++ b/packages/bonde-admin/src/1corelib/plugins/content/plugin.js
@@ -37,7 +37,7 @@ class Content extends React.Component {
   }
 }
 
-const { object, shape, func, string, oneOfType } = PropTypes
+const { object, shape, string, oneOfType } = PropTypes
 
 Content.propTypes = {
   mobilization: object.isRequired,
@@ -46,7 +46,8 @@ Content.propTypes = {
       content: oneOfType([string, object]).isRequired
     }),
   }).isRequired,
-  update: func,
+  // Used to render draft editor
+  decorator: PropTypes.object.isRequired,
   intl: intlShape.isRequired
 }
 

--- a/packages/bonde-admin/src/1corelib/plugins/content/plugin.js
+++ b/packages/bonde-admin/src/1corelib/plugins/content/plugin.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { injectIntl, intlShape } from 'react-intl'
+// TODO: should remove EditorOld??
+import { DraftEditor, SlateEditor } from './components'
+
+class Content extends React.Component {
+
+  render () {
+    const { widget: { settings } } = this.props
+
+    try {
+      // If parse content is RebooEditor
+      const content = JSON.parse(settings.content)
+      return content.entityMap ? (
+        <DraftEditor {...this.props} />
+      ) : (
+        <SlateEditor {...this.props} content={settings.content} readOnly />
+      )
+    } catch (e) {
+      // TODO: not silenty exception
+      // Else is old editor
+      /*if (this.state.forceRenderNewEditor) {
+        return (
+          <EditorNew {...this.props}
+          />
+        )
+      } else {
+        return (
+          <EditorOld
+            handleForceRender={this.handleForceRender.bind(this)}
+            {...this.props}
+          />
+        )
+      }*/
+    }
+  }
+}
+
+const { object, shape, func, string, oneOfType } = PropTypes
+
+Content.propTypes = {
+  mobilization: object.isRequired,
+  widget: shape({
+    settings: shape({
+      content: oneOfType([string, object]).isRequired
+    }),
+  }).isRequired,
+  update: func,
+  intl: intlShape.isRequired
+}
+
+export default injectIntl(Content)

--- a/packages/bonde-admin/src/pages/admin/mobilizations/edit/preview.js
+++ b/packages/bonde-admin/src/pages/admin/mobilizations/edit/preview.js
@@ -10,6 +10,7 @@ import { FormTellAFriend } from '@/mobilizations/widgets/__plugins__/form/compon
 import AnalyticsEvents from '@/mobilizations/widgets/utils/analytics-events'
 // CONTENT PLUGIN and external dependencies
 import { ContentPlugin } from '@mobs/plugins/content'
+import { decorator } from '@/components/editor-draft-js/Toolbar'
 // TODO: Migrate this plugins
 import { Donation, Pressure } from '@/mobilizations/widgets/__plugins__'
 // TODO: Review this concept
@@ -79,7 +80,12 @@ const plugins = [
   },
   {
     kind: 'content',
-    component: ContentPlugin,
+    component: (props) => (
+      <ContentPlugin
+        {...props}
+        decorator={decorator}
+      />
+    ),
     options: Object.assign(
       {},
       DraftPlugin.setOptions({

--- a/packages/bonde-admin/src/pages/admin/mobilizations/edit/preview.js
+++ b/packages/bonde-admin/src/pages/admin/mobilizations/edit/preview.js
@@ -8,8 +8,10 @@ import { FormPlugin } from '@mobs/plugins/form'
 import { FinishMessageCustom } from '@/mobilizations/widgets/components'
 import { FormTellAFriend } from '@/mobilizations/widgets/__plugins__/form/components'
 import AnalyticsEvents from '@/mobilizations/widgets/utils/analytics-events'
+// CONTENT PLUGIN and external dependencies
+import { ContentPlugin } from '@mobs/plugins/content'
 // TODO: Migrate this plugins
-import { Content, Donation, Pressure } from '@/mobilizations/widgets/__plugins__'
+import { Donation, Pressure } from '@/mobilizations/widgets/__plugins__'
 // TODO: Review this concept
 import { mobrenderHOC } from '@/mobrender/components/mobilization.connected'
 // TODO: Icons should be inside plugin reference.
@@ -77,7 +79,7 @@ const plugins = [
   },
   {
     kind: 'content',
-    component: Content,
+    component: ContentPlugin,
     options: Object.assign(
       {},
       DraftPlugin.setOptions({


### PR DESCRIPTION
Segundo plugin da série de plugins que serão movidos para um modelo mais flexível de renderização da mobilização.

Diretório padrão: src/1corelib/plugins/content
Branch original: https://github.com/nossas/bonde-client/tree/feature/move-mobilization-render