### PR TITLE
Hotfix/donation pagarme key

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "npmClient": "yarn"
     }
   },
-  "version": "0.10.2-alpha.0"
+  "version": "0.10.3-alpha.0"
 }

--- a/packages/bonde-admin-canary/package.json
+++ b/packages/bonde-admin-canary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bonde-admin-canary",
-  "version": "0.10.2-alpha.0",
+  "version": "0.10.3-alpha.0",
   "private": true,
   "dependencies": {
     "apollo-boost": "^0.1.10",

--- a/packages/bonde-admin/package.json
+++ b/packages/bonde-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bonde-admin",
-  "version": "0.10.2-alpha.0",
+  "version": "0.10.3-alpha.0",
   "description": "Bonde Admin - Node.js Server and React + Redux Progressive Web App",
   "author": "Nossas <tech@nosssas.org>",
   "homepage": "http://bonde.org",
@@ -27,7 +27,7 @@
     "axios": "^0.18.0",
     "axios-mock-adapter": "^1.16.0",
     "basscss-sass": "^4.0.0",
-    "bonde-webpage": "0.10.2-alpha.4",
+    "bonde-webpage": "^0.10.3-alpha.0",
     "chai": "^4.2.0",
     "cpf_cnpj": "^0.2.0",
     "cross-storage": "^1.0.0",

--- a/packages/bonde-admin/src/mobilizations/widgets/__plugins__/form/components/input-form.js
+++ b/packages/bonde-admin/src/mobilizations/widgets/__plugins__/form/components/input-form.js
@@ -233,34 +233,34 @@ export class InputForm extends Component {
                   onChange={this.handleKindChange.bind(this)}
                   value={this.state.kind}>
                   <option value='text'>
-                    <FormattedMessage
-                      id='form-widget.components--input-form.field-type.options.text'
-                      defaultMessage='Texto'
-                    />
+                    {intl.formatMessage({
+                      id: 'form-widget.components--input-form.field-type.options.text',
+                      defaultMessage: 'Texto'
+                    })}
                   </option>
                   <option value='email'>
-                    <FormattedMessage
-                      id='form-widget.components--input-form.field-type.options.email'
-                      defaultMessage='E-mail'
-                    />
+                    {intl.formatMessage({
+                      id: 'form-widget.components--input-form.field-type.options.email',
+                      defaultMessage: 'E-mail'
+                    })}
                   </option>
                   <option value='number'>
-                    <FormattedMessage
-                      id='form-widget.components--input-form.field-type.options.number'
-                      defaultMessage='Número'
-                    />
+                    {intl.formatMessage({
+                      id: 'form-widget.components--input-form.field-type.options.number',
+                      defaultMessage: 'Número'
+                    })}
                   </option>
                   <option value='dropdown'>
-                    <FormattedMessage
-                      id='form-widget.components--input-form.field-type.options.dropdown'
-                      defaultMessage='Dropdown &#9733;'
-                    />
+                    {intl.formatMessage({
+                      id: 'form-widget.components--input-form.field-type.options.dropdown',
+                      defaultMessage: 'Dropdown &#9733;'
+                    })}
                   </option>
                   <option value='greetings'>
-                    <FormattedMessage
-                      id='form-widget.components--input-form.field-type.options.greetings'
-                      defaultMessage='Saudação &#9733;'
-                    />
+                    {intl.formatMessage({
+                      id: 'form-widget.components--input-form.field-type.options.greetings',
+                      defaultMessage: 'Saudação &#9733;'
+                    })}
                   </option>
                 </select>
               </div>

--- a/packages/bonde-public/next.config.js
+++ b/packages/bonde-public/next.config.js
@@ -21,7 +21,8 @@ module.exports = withCSS(withSass({
     publicRuntimeConfig: {
       domainApiRest: process.env.REACT_APP_DOMAIN_API_REST,
       domainApiGraphql: process.env.REACT_APP_DOMAIN_API_GRAPHQL,
-      domainPublic: process.env.REACT_APP_DOMAIN_PUBLIC
+      domainPublic: process.env.REACT_APP_DOMAIN_PUBLIC,
+      pagarmeKey: process.env.REACT_APP_PAGARME_KEY
     }
   })
 )

--- a/packages/bonde-public/package.json
+++ b/packages/bonde-public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bonde-public",
-  "version": "0.10.2-alpha.0",
+  "version": "0.10.3-alpha.0",
   "description": "Bonde Public - Responsible render a mobilization on public mode",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,7 @@
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-sass": "^1.0.1",
     "axios": "0.18.0",
-    "bonde-webpage": "0.10.2-alpha.4",
+    "bonde-webpage": "^0.10.3-alpha.0",
     "chain-function": "^1.0.0",
     "classnames": "2.2.6",
     "dotenv": "^4.0.0",

--- a/packages/bonde-public/pages/mobilization.connected.js
+++ b/packages/bonde-public/pages/mobilization.connected.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactGA from 'react-ga'
+import getConfig from 'next/config'
 // MOBILIZATION and external dependencies
 import { Mobilization } from 'bonde-webpage'
 import { PluggableWidget, FinishMessageCustom } from 'bonde-webpage/lib/ux'
@@ -22,6 +23,9 @@ import { DonationAnalytics, DonationTellAFriend } from 'bonde-webpage/lib/plugin
 
 import { connect } from 'react-redux'
 import { selectors as MobilizationSelectors } from 'bonde-webpage/lib/redux'
+
+
+const { publicRuntimeConfig } = getConfig()
 
 const mapStateToProps = (state, props) => {
   const query = MobilizationSelectors(state, props)
@@ -73,6 +77,7 @@ const plugins = [
     component: (props) => (
       <DonationPlugin
         {...props}
+        pagarmeKey={publicRuntimeConfig.pagarmeKey}
         analyticsEvents={DonationAnalytics}
         overrides={{
           FinishCustomMessage: { component: FinishMessageCustom },

--- a/packages/bonde-webpage/package.json
+++ b/packages/bonde-webpage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bonde-webpage",
-  "version": "0.10.2-alpha.4",
+  "version": "0.10.3-alpha.0",
   "private": false,
   "main": "lib/index.js",
   "files": [

--- a/packages/bonde-webpage/src/lib/plugins/donation/plugin.connected.js
+++ b/packages/bonde-webpage/src/lib/plugins/donation/plugin.connected.js
@@ -1,7 +1,8 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Donation from './plugin'
 
-export default class extends React.Component {
+class DonationConnected extends React.Component {
   constructor (props) {
     super(props)
     this.state = { donationCustomerData: undefined }
@@ -24,7 +25,7 @@ export default class extends React.Component {
         : '#43a2cc'
 
       const checkout = new window.PagarMeCheckout.Checkout({
-        encryption_key: process.env.REACT_APP_PAGARME_KEY || 'setup env var',
+        encryption_key: this.props.pagarmeKey || 'setup env var',
         success: (data) => {
           data.subscription = paymentType === 'users_choice'
             ? (selectedPaymentType !== 'unique')
@@ -108,6 +109,12 @@ export default class extends React.Component {
     )
   }
 }
+
+DonationConnected.propTypes = {
+  pagarmeKey: PropTypes.string.isRequired
+}
+
+export default DonationConnected
 
 /* TOOD: script inserted on top level for rendering, but need thing a better solution
 // eslint-disable-next-line


### PR DESCRIPTION
- Fix #1038

Chegamos a conclusão que o bonde-webpage deve sempre considerar que informações sobre configuração do plugin devem ser passadas como propriedade, mantendo o formato que considera o plugin uma extensão do webpage, podendo ser configurado de forma única, ficando sobre responsabilidade do cliente essa configuração.