### PR TITLE
Allows empty forms to be sent

### DIFF
--- a/packages/bonde-webpage/src/lib/plugins/form/plugin.js
+++ b/packages/bonde-webpage/src/lib/plugins/form/plugin.js
@@ -23,19 +23,11 @@ class Form extends Component {
     return fields.filter(f => f.kind !== 'greetings')
   }
 
-  processEmptyForms(widget) {
-    if (!widget.settings.fields) {
-      widget.settings.fields = []
-    }
-  }
-
   submit (e) {
     e.preventDefault()
 
     const { asyncFormEntryCreate, mobilization, widget } = this.props
     const { values } = this.state
-
-    this.processEmptyForms(widget)
 
     const fieldsWithValue = widget.settings.fields.map(field => ({
       ...field,
@@ -124,7 +116,7 @@ class Form extends Component {
   renderButton () {
     const { widget, intl } = this.props
     const { loading, success } = this.state  
-    return (
+    return widget.settings.fields && (
       <Button
         {...this.props}
         buttonText={

--- a/packages/bonde-webpage/src/lib/plugins/form/plugin.js
+++ b/packages/bonde-webpage/src/lib/plugins/form/plugin.js
@@ -23,11 +23,19 @@ class Form extends Component {
     return fields.filter(f => f.kind !== 'greetings')
   }
 
+  processEmptyForms(widget) {
+    if (!widget.settings.fields) {
+      widget.settings.fields = []
+    }
+  }
+
   submit (e) {
     e.preventDefault()
 
     const { asyncFormEntryCreate, mobilization, widget } = this.props
     const { values } = this.state
+
+    this.processEmptyForms(widget)
 
     const fieldsWithValue = widget.settings.fields.map(field => ({
       ...field,


### PR DESCRIPTION
There was a bug in which empty forms could not be sent. This PR solves this bug by assigning an empty array to `fields` property in widget's `settings` property.