### PR TITLE
[admin] altera estrategia de redirecionamento para atualização do react-router

### DIFF
--- a/packages/bonde-admin/src/mobilizations/widgets/__plugins__/form/components/__form__.js
+++ b/packages/bonde-admin/src/mobilizations/widgets/__plugins__/form/components/__form__.js
@@ -5,7 +5,6 @@ import { intlShape } from 'react-intl'
 import $ from 'jquery'
 import classnames from 'classnames'
 
-import * as paths from '@/paths'
 import { Error } from '@/components/form-util'
 import { isValidEmail } from '@/utils/validation-helper'
 import { FinishMessageCustom } from '@/mobilizations/widgets/components'
@@ -32,13 +31,6 @@ class Form extends Component {
   fields () {
     const { settings } = this.props.widget
     return (settings && settings.fields ? settings.fields : [])
-  }
-
-  handleOverlayOnClick () {
-    const { browserHistory, mobilization, widget, editable } = this.props
-    if (editable) {
-      browserHistory.push(paths.fieldsMobilizationWidget(mobilization.id, widget.id))
-    }
   }
 
   submit () {

--- a/packages/bonde-admin/src/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
+++ b/packages/bonde-admin/src/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
 import { client as graphqlClient } from '@/store'
 import * as graphqlMutations from '@/graphql/mutations'
 import * as graphqlQueries from '@/graphql/queries'
@@ -138,10 +139,10 @@ export class Pressure extends Component {
   }
 
   handleOverlayOnClick (e) {
-    const { browserHistory, mobilization, widget, editable } = this.props
+    const { history, mobilization, widget, editable } = this.props
     if (editable) {
       if (e) e.preventDefault()
-      browserHistory.push(
+      history.push(
         paths.pressure(mobilization.id, widget.id)
       )
     }
@@ -258,7 +259,4 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = { ...PressureActions }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Pressure)
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(Pressure))

--- a/packages/bonde-admin/src/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
+++ b/packages/bonde-admin/src/mobilizations/widgets/__plugins__/pressure/components/__pressure__.js
@@ -10,7 +10,7 @@ import * as paths from '@/paths'
 import * as array from '@/utils/array'
 import MobSelectors from '@/mobrender/redux/selectors'
 import * as PressureActions from '../action-creators'
-import { WidgetOverlay, FinishMessageCustom } from '@/mobilizations/widgets/components'
+import { FinishMessageCustom } from '@/mobilizations/widgets/components'
 import { PressureCount, PressureForm, TargetList, PressureTellAFriend } from '../components'
 
 /* TODO: Change static content by props
@@ -177,60 +177,52 @@ export class Pressure extends Component {
       disable_edit_field: 'n'
     }
 
-    return (
-      <WidgetOverlay
-        editable={editable}
-        onClick={this.handleOverlayOnClick.bind(this)}
-        text='Clique para configurar o formulário de pressão direta'
-      >
-        {filledPressureWidgets.includes(widget.id) || this.state.showFinishMessage ? (
-          finishMessageType === 'custom' ? (
-            <FinishMessageCustom widget={widget} />
-          ) : (
-            <PressureTellAFriend mobilization={mobilization} widget={widget} />
-          )
-        ) : (
-          <div className='pressure-widget'>
-            <div onKeyDown={(e) => e.stopPropagation()} />
-            <h2
-              className='center py2 px3 m0 white rounded-top'
-              style={{ backgroundColor: mainColor, fontFamily: headerFont }}
-            >
-              {callToAction || titleText}
-            </h2>
-            <TargetList
-              targets={this.getTargetList() || []}
-              onSelect={this.changeSelectedTargets.bind(this)}
-              errorMessage={this.state.selectedTargetsError}
-              selectable={this.selectableTargetList}
+    return filledPressureWidgets.includes(widget.id) || this.state.showFinishMessage ? (
+      finishMessageType === 'custom' ? (
+        <FinishMessageCustom widget={widget} />
+      ) : (
+        <PressureTellAFriend mobilization={mobilization} widget={widget} />
+      )
+    ) : (
+      <div className='pressure-widget'>
+        <div onKeyDown={(e) => e.stopPropagation()} />
+        <h2
+          className='center py2 px3 m0 white rounded-top'
+          style={{ backgroundColor: mainColor, fontFamily: headerFont }}
+        >
+          {callToAction || titleText}
+        </h2>
+        <TargetList
+          targets={this.getTargetList() || []}
+          onSelect={this.changeSelectedTargets.bind(this)}
+          errorMessage={this.state.selectedTargetsError}
+          selectable={this.selectableTargetList}
+        />
+        <PressureForm
+          disabled={disableEditField === 's'}
+          widget={widget}
+          mobilization={mobilization}
+          buttonText={(saving && !editable ? 'Enviando...' : buttonText)}
+          buttonColor={mainColor}
+          subject={pressureSubject}
+          body={pressureBody}
+          onSubmit={this.handleSubmit.bind(this)}
+          targetList={this.getTargetList()}
+          selectedTargets={this.selectedTargets}
+          callTransition={this.state.callTransition}
+          addTwilioCallMutation={this.state.addTwilioCallMutation}
+          changeParentState={this.changeState.bind(this)}
+        >
+          {countText && (
+            <PressureCount
+              value={this.state.phonePressureCount || widget.count || 0}
+              color={mainColor}
+              text={countText}
+              startCounting={block.scrollTopReached}
             />
-            <PressureForm
-              disabled={disableEditField === 's'}
-              widget={widget}
-              mobilization={mobilization}
-              buttonText={(saving && !editable ? 'Enviando...' : buttonText)}
-              buttonColor={mainColor}
-              subject={pressureSubject}
-              body={pressureBody}
-              onSubmit={this.handleSubmit.bind(this)}
-              targetList={this.getTargetList()}
-              selectedTargets={this.selectedTargets}
-              callTransition={this.state.callTransition}
-              addTwilioCallMutation={this.state.addTwilioCallMutation}
-              changeParentState={this.changeState.bind(this)}
-            >
-              {countText && (
-                <PressureCount
-                  value={this.state.phonePressureCount || widget.count || 0}
-                  color={mainColor}
-                  text={countText}
-                  startCounting={block.scrollTopReached}
-                />
-              )}
-            </PressureForm>
-          </div>
-        )}
-      </WidgetOverlay>
+          )}
+        </PressureForm>
+      </div>
     )
   }
 }

--- a/packages/bonde-admin/src/mobrender/components/widget.spec.js
+++ b/packages/bonde-admin/src/mobrender/components/widget.spec.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { expect } from 'chai'
 import shallowWithIntl from '@/intl/helpers/shallow-with-intl'
+import Pressure from '@/mobilizations/widgets/__plugins__/pressure/components'
 import Widget from '@/mobrender/components/widget'
 import WidgetOverlay from '@/mobrender/components/widget-overlay.connected'
 
@@ -62,7 +63,7 @@ describe('client/mobrender/components/widget', () => {
     it('should render pressure widget component', () => {
       const widget = shallowWithIntl(<Widget {...props} editable={false} />)
       widget.setProps({ ...props, widget: { ...props.widget, kind: 'pressure' } })
-      expect(widget.find('Connect(Pressure)').length).to.equal(1)
+      expect(widget.find(Pressure).length).to.equal(1)
     })
 
     it('should render form widget component', () => {

--- a/packages/bonde-admin/src/pages/admin/mobilizations/launch-end/page.connected.js
+++ b/packages/bonde-admin/src/pages/admin/mobilizations/launch-end/page.connected.js
@@ -3,6 +3,7 @@
 //
 import { provideHooks } from 'redial'
 import { connect } from 'react-redux'
+import { withRouter } from "react-router"
 
 import MobSelectors from '@/mobrender/redux/selectors'
 import * as MobActions from '@/mobrender/redux/action-creators'
@@ -25,5 +26,5 @@ const mapStateToProps = state => ({
 })
 
 export default provideHooks(redial)(
-  connect(mapStateToProps)(Page)
+  connect(mapStateToProps)(withRouter(Page))
 )

--- a/packages/bonde-admin/src/pages/admin/mobilizations/launch-end/page.js
+++ b/packages/bonde-admin/src/pages/admin/mobilizations/launch-end/page.js
@@ -24,7 +24,7 @@ const Image = ({ image }) => (
   <div className='image' style={{ backgroundImage: `url(${image})` }} />
 )
 
-const MobilizationsLaunchPage = ({ browserHistory, mobilization: { id, facebook_share_image: image } }) => {
+const MobilizationsLaunchPage = ({ history, mobilization: { id, facebook_share_image: image } }) => {
   return (
     <PageCentralizedLayout>
       <PageCentralizedLayoutTitle>
@@ -37,7 +37,7 @@ const MobilizationsLaunchPage = ({ browserHistory, mobilization: { id, facebook_
       <div className='mobilization-launch-end'>
         <Heading />
         <Image image={image} />
-        <Button onClick={() => browserHistory.push(paths.editMobilization(id))}>
+        <Button onClick={() => history.push(paths.editMobilization(id))}>
           <FormattedMessage
             id='page--mobilizations-launch-end.button'
             defaultMessage='Lançar mobilização'


### PR DESCRIPTION
## Contexto
Além de alguns trechos de código que não estavam sendo usados, ainda existe em algumas páginas a estrategia de redirecionamento antiga, antes da atualização da biblioteca react-router

## Checklist
- [X] Remover trechos de códigos que não estão sendo utilizados
- [X] Substituir uso de browserHistory por history passado por props

## Issues linkadas
- Resolves #1078

## Como testar?
1. Faça lançamento de uma mobilização atraves da opção no menu Sidebar chamada `Lançar Mobilização`
2. Você deve concluir todas as etapas sem nenhum problema