### PR TITLE
Feature/create campaign validations

### DIFF
--- a/packages/bonde-admin-canary/public/locales/pt-BR/chatbot.json
+++ b/packages/bonde-admin-canary/public/locales/pt-BR/chatbot.json
@@ -1,0 +1,10 @@
+{
+    "flows": {
+        "createCampaign": {
+            "validations": {
+                "uniqueEntry": "Parâmetro {{field}} já foi utilizado anteriormente",
+                "noSpaces": "Parâmetro {{field}} não pode conter espaços"
+            }
+        }
+    }
+}

--- a/packages/bonde-admin-canary/src/scenes/Logged/scenes/Chatbot/components/CreateFlowModalForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Logged/scenes/Chatbot/components/CreateFlowModalForm.js
@@ -13,9 +13,10 @@ import { FormGraphQL, Field, SubmitButton, resetForm } from 'components/Form'
 import { required } from 'services/validations'
 import ChatbotAPI from '../graphql'
 
-
-export default ({ community }) => {
+export default ({ t, community }) => {
   const [opened, setOpened] = useState(false)
+  const [errors, setErrors] = useState([])
+  const [lastValues, setLastValues] = useState({})
 
   const handleCloseModalForm = () => {
     // Should resetForm always close modal
@@ -56,8 +57,14 @@ export default ({ community }) => {
               // TODO: discuss how to implement the relationship of configurations, communities and bots
               // chatbotSettingsId = 1 represents BETA the first bot
               return mutation({ variables: {...values, chatbotSettingsId: 1 }})
-                .then(() => {
+                .then((a) => {
                   handleCloseModalForm()
+                })
+                .catch((err) => {
+                  setLastValues(values)
+                  if (err.graphQLErrors && err.graphQLErrors.length > 0 && err.graphQLErrors[0].message) {
+                    setErrors(JSON.parse(err.graphQLErrors[0].message))
+                  }
                 })
             }}
           >
@@ -72,10 +79,15 @@ export default ({ community }) => {
             <Field
               name='prefix'
               label='Identificador'
-              placeholder='Identificador usado para agrupar mensagens'
+              placeholder='Identificador usado parI18na agrupar mensagens'
               component={FormField}
               inputComponent={Input}
-              validate={required('Identificador deve ser preenchida.')}
+              validate={
+                message => {
+                  return required('Identificador deve ser preenchida.')(message) ||
+                  lastValues.prefix === message && t(errors.prefix, {field: 'prefix'})
+                }
+              }
             />
             <Field
               name='message'

--- a/packages/bonde-admin-canary/src/scenes/Logged/scenes/Chatbot/scenes/Flows/index.js
+++ b/packages/bonde-admin-canary/src/scenes/Logged/scenes/Chatbot/scenes/Flows/index.js
@@ -6,6 +6,7 @@ import {
   Title
 } from 'bonde-styleguide'
 import { CreateFlowModalForm, FlowDataList } from '../../components'
+import { I18n } from 'react-i18next';
 
 export default ({ changeCampaign, community, edges }) => {
   // TODO:
@@ -15,7 +16,11 @@ export default ({ changeCampaign, community, edges }) => {
     <Flexbox vertical>
       <Flexbox horizontal spacing='between'>
         <Title.H2 margin={{ bottom: 10 }}>Chatbot</Title.H2>
-        <CreateFlowModalForm community={community} />
+        <I18n ns='chatbot'>
+          {t => (
+            <CreateFlowModalForm t={t} community={community} />
+          )}
+        </I18n>
       </Flexbox>
       <Title.H5 margin={{ bottom: 25 }}>FLUXOS DE CONVERSA</Title.H5>
       <Grid>


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->
No modal, na cena Flow, da criação de uma nova campanha, não existe validação para o campo `prefix` com relação à nomes duplicados e a existência de espaçamento. Esse PR resolve esse problema.

## Checklist
- [x] Mostrar mensagem de erro para o caso do campo identificador já ter sido usado.
- [x] Mostrar mensagem de erro para o caso do campo identificador conter algum espaçamento.
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [ ] Resolves #1150 
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->
Acessar URL http://admin-canary.bonde.devel:5002/admin/1/chatbot, criar um novo fluxo de conversa e tentar adicionar duas campanhas com identificador igual, e também uma campanha com identificador com espaçamento