### PR TITLE
Feature/root card delete

### DIFF
--- a/packages/bonde-admin-canary/src/scenes/Logged/scenes/Chatbot/components/ConversationTree.js
+++ b/packages/bonde-admin-canary/src/scenes/Logged/scenes/Chatbot/components/ConversationTree.js
@@ -89,7 +89,7 @@ const SimpleNodeLabel = ({ nodeData, nodeDataSelected, onInsertClick, onDeleteCl
       </Flexbox>
       {active && (
         <React.Fragment>
-          <DeleteButton onClick={onDeleteClick} />
+          {nodeData.level > 1 && <DeleteButton onClick={onDeleteClick} />}
           <InsertButton onClick={onInsertClick} />
         </React.Fragment>
       )}


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->

Esse PR impede que aconteça o problema que é gerado ao deletar o card raiz de uma campanha.
Para isso, basicamente, ele esconde o botão de deletar de todos os cards com level = 1.

## Checklist
- [ ] Impedir que o card raiz daquela campanha possa ser deletado.
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [ ] #1151 
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Screenshots
<!-- Adicione algumas imagens para haver um preview da sua tarefa, para ajudar desenvolvedores e designers a entender facilmente no que você está trabalhando. -->

### Preview:
![image](https://user-images.githubusercontent.com/7359906/60903791-5e014f80-a248-11e9-9e01-2560c6276657.png)

## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->

Criar uma campanha, entrar na tela de edição da árvore de mensagens, e notar que o botão para deletar um card nunca aparece no card raiz.
