### PR TITLE
fix(admin): remove redirect to /confirm

### DIFF
--- a/packages/bonde-admin/src/pages/public/subscription-edit/page.js
+++ b/packages/bonde-admin/src/pages/public/subscription-edit/page.js
@@ -169,22 +169,22 @@ class SubscriptionEditPage extends React.Component {
             <p
               className='link--cancel center mt3 lightgray link'
               style={{ color: '#999999', cursor: 'pointer' }}
-                onClick={() => {
-                  const message = intl.formatMessage({
-                    id: 'page--subscription-edit.cancel-subscription.confirm',
-                    defaultMessage: 'Você está prestes a cancelar sua assinatura. ' +
-                      'Tem certeza que quer continuar?'
-                  })
+              onClick={() => {
+                const message = intl.formatMessage({
+                  id: 'page--subscription-edit.cancel-subscription.confirm',
+                  defaultMessage: 'Você está prestes a cancelar sua assinatura. ' +
+                    'Tem certeza que quer continuar?'
+                })
 
-                  if (window.confirm(message)) {
-                    asyncSubscriptionDelete(initialValues)
-                  }
-                }}
-              >
-                <FormattedMessage
-                  id='page--subscription-edit.link.cancel-subscription'
-                  defaultMessage='Quero cancelar a minha assinatura.'
-                />
+                if (window.confirm(message)) {
+                  asyncSubscriptionDelete(initialValues)
+                }
+              }}
+            >
+              <FormattedMessage
+                id='page--subscription-edit.link.cancel-subscription'
+                defaultMessage='Quero cancelar a minha assinatura.'
+              />
             </p>
           </section>
         </Background>

--- a/packages/bonde-admin/src/pages/public/subscription-edit/page.js
+++ b/packages/bonde-admin/src/pages/public/subscription-edit/page.js
@@ -166,9 +166,9 @@ class SubscriptionEditPage extends React.Component {
               )
             })}
 
-            <p className='link--cancel center mt3 lightgray link'>
-              <a href='/confirm'
-                style={{ color: '#999999' }}
+            <p
+              className='link--cancel center mt3 lightgray link'
+              style={{ color: '#999999', cursor: 'pointer' }}
                 onClick={() => {
                   const message = intl.formatMessage({
                     id: 'page--subscription-edit.cancel-subscription.confirm',
@@ -185,7 +185,6 @@ class SubscriptionEditPage extends React.Component {
                   id='page--subscription-edit.link.cancel-subscription'
                   defaultMessage='Quero cancelar a minha assinatura.'
                 />
-              </a>
             </p>
           </section>
         </Background>


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->

Quando o usuário tenta cancelar sua inscrição em uma recorrência, a requisição não é enviada ao servidor. Ao realizar os testes, notei que havia um redirecionamento para a url `/confirm`, entretanto, não encontrei nenhum tipo de tratamento para essa URL no sistema.

A solução encontrada foi remover a tag `a` da página, para evitar que a requisição para cancelamento de inscrição seja cancelada.

## Issues linkadas
- [ ] #1109 
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->

Após se inscrever para uma doação recorrente, clicar no link recebido no email para realizar o cancelamento da inscrição, e após clicar na mensagem "Quero cancelar minha doação", verificar que o cancelamento foi realizado com sucesso.