### PR TITLE
Feature/remove jquery navBar and EditorOld

### DIFF
--- a/packages/bonde-admin/src/components/navigation/navbar/navbar-button.js
+++ b/packages/bonde-admin/src/components/navigation/navbar/navbar-button.js
@@ -1,19 +1,14 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import classnames from 'classnames'
-import $ from 'jquery'
 
 const NavbarButton = props => {
   const handleClick = e => {
     e.preventDefault()
-    const { targetId, scrollableId } = props
-    const target = $(`#${targetId}`)
-    const scrollable = $(`#${scrollableId}`)
-    const yPosition = target.position().top + scrollable.scrollTop() - scrollable.position().top
+    const { targetId } = props
+    const target = document.getElementById(targetId)
 
-    scrollable.stop().animate({scrollTop: yPosition}, 500, () => {
-      window.location.hash = targetId
-    })
+    target.scrollIntoView({behavior: "smooth"})
   }
 
   const {className, children, hidden} = props

--- a/packages/bonde-admin/src/mobilizations/widgets/__plugins__/content/components/editor-old.js
+++ b/packages/bonde-admin/src/mobilizations/widgets/__plugins__/content/components/editor-old.js
@@ -73,15 +73,17 @@ class EditorOld extends React.Component {
   }
 
   setClick () {
-    const links = document.querySelectorAll('.content-widget a:not([target="_blank"])')
-    for (let link of links) {
-      document.addEventListener('click touchstart', function(e) {
-        this.handleClick.bind(this)
-      })
+    const on = (selector, event, handler, element = document) => {
+      element.addEventListener(event, (e) => { if(e.target.matches(selector)) handler(e); });
     }
+
+    window.addEventListener('click touchstart', function(e) {
+      on('.content-widget a:not([target="_blank"])','click touchstart', this.handleClick.bind(this))
+    })
   }
 
   handleClick (e) {
+    console.log(e)
     e.preventDefault()
     const target = document.getElementById(e.target)
 

--- a/packages/bonde-admin/src/mobilizations/widgets/__plugins__/content/components/editor-old.js
+++ b/packages/bonde-admin/src/mobilizations/widgets/__plugins__/content/components/editor-old.js
@@ -81,14 +81,11 @@ class EditorOld extends React.Component {
   }
 
   handleClick (e) {
+    console.log(e)
     e.preventDefault()
-    const target = $(e.target).closest('a').prop('hash')
-    const scrollable = $('#blocks-list')
-    const yPosition = $(target).offset().top + scrollable.scrollTop() - scrollable.position().top
+    const target = document.getElementById(e.target)
 
-    scrollable.stop().animate({scrollTop: yPosition}, 500, () => {
-      window.location.hash = target
-    })
+    target.scrollIntoView({behavior: "smooth"})
   }
 
   save () {

--- a/packages/bonde-admin/src/mobilizations/widgets/__plugins__/content/components/editor-old.js
+++ b/packages/bonde-admin/src/mobilizations/widgets/__plugins__/content/components/editor-old.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import $ from 'jquery'
 import classnames from 'classnames'
 
 // Global module dependencies
@@ -76,7 +75,9 @@ class EditorOld extends React.Component {
   setClick () {
     const links = document.querySelectorAll('.content-widget a:not([target="_blank"])')
     for (let link of links) {
-      $(link).on('click touchstart', this.handleClick.bind(this))
+      document.addEventListener('click touchstart', function(e) {
+        this.handleClick.bind(this)
+      })
     }
   }
 

--- a/packages/bonde-admin/src/mobilizations/widgets/__plugins__/content/components/editor-old.js
+++ b/packages/bonde-admin/src/mobilizations/widgets/__plugins__/content/components/editor-old.js
@@ -82,7 +82,6 @@ class EditorOld extends React.Component {
   }
 
   handleClick (e) {
-    console.log(e)
     e.preventDefault()
     const target = document.getElementById(e.target)
 


### PR DESCRIPTION
## Contexto
remove o seletor do jQuery nos componentes de `NavBar` e `EditorOld`

## Issues linkadas
- #1197

## Como testar?
Na página de edição de mobilização