### PR TITLE
[admin-canary]: refactor resize screen height

### DIFF
--- a/packages/bonde-admin-canary/src/components/PageLogged/Page.js
+++ b/packages/bonde-admin-canary/src/components/PageLogged/Page.js
@@ -15,7 +15,7 @@ const Page = ({
   // calculate height to resize content and fix Footer component on bottom page
   const height = (window.innerHeight ||
     document.documentElement.clientHeight ||
-    document.body.clientHeight) - 158
+    document.body.clientHeight)
 
   const headerNode = (
     <Header


### PR DESCRIPTION
refatora o cálculo da altura da página

Antes: 
![Captura de Tela 2019-07-30 às 15 42 20](https://user-images.githubusercontent.com/38147979/62156098-b2946980-b2e0-11e9-925e-a52bc5db858c.png)

Depois:
![Captura de Tela 2019-07-30 às 15 49 50](https://user-images.githubusercontent.com/38147979/62156590-b2e13480-b2e1-11e9-81fb-6e5697752b56.png)
