### PR TITLE
Feature/hasura graphql

### DIFF
--- a/packages/bonde-admin-canary/src/services/auth/AuthProvider.js
+++ b/packages/bonde-admin-canary/src/services/auth/AuthProvider.js
@@ -36,7 +36,8 @@ class AuthProvider extends React.Component {
         const authErrors = [
           'Token invalid, user not found.',
           'Signature verification failed',
-          'Invalid audience'
+          'Invalid audience',
+          'jwt expired'
         ]
 
         if (typeof error === 'object' && authErrors.indexOf(error.graphQLErrors[0].message) !== -1) {

--- a/packages/bonde-admin-canary/src/services/graphql/client.js
+++ b/packages/bonde-admin-canary/src/services/graphql/client.js
@@ -10,17 +10,24 @@ const httpLink = createHttpLink({
 })
 
 const authLink = setContext((_, { headers }) => {
-  const token = authSession.getToken()
+  const hasuraToken = process.env.REACT_APP_HASURA_SECRET || 'segredo123'
+  const authToken = authSession.getToken()
 
-  if (token) {
+  if (authToken) {
     return {
       headers: {
         ...headers,
-        authorization: `Bearer ${token}`
+        authorization: `Bearer ${authToken}`,
+        'x-hasura-admin-secret': hasuraToken
       }
     }
   }
-  return { headers }
+  return {
+    headers: {
+      ...headers,
+      'x-hasura-admin-secret': hasuraToken
+    }
+  }
 })
 
 const handleError = onCatch(({ networkError }) => {


### PR DESCRIPTION
## Contexto
Adicionar váriavel de ambiente para ter acesso ao `Hasura GraphQL API` no admin-canary, dessa forma é possível utilizar tanto a API-v2 quanto fazer track das tabelas que o Hasura tem acesso.

## Notas de deploy
Configurar váriavel de ambiente:

`REACT_APP_HASURA_SECRET`: Token de acesso ao Hasura

## Como testar?

* Mudar váriavel de ambiente `REACT_APP_DOMAIN_API_GRAPHQL` para endereço do server Hasura, e adicionar váriavel de ambiente `REACT_APP_HASURA_SECRET` com mesmo valor configurado no servidor.

* Após configurar o ambiente e reinicar o serviço, você deve conseguir acessar a plataforma sem nenhum problema com as requisições GraphQL.