### PR TITLE
feat(public): add authenticate to use Hasura

### DIFF
--- a/packages/bonde-public/global.d.ts
+++ b/packages/bonde-public/global.d.ts
@@ -4,7 +4,8 @@ declare module 'next/config' {
       domainApiRest: string
       domainApiGraphql: string
       domainPublic: string
-      pagarmeKey: string
+      pagarmeKey: string,
+      hasuraSecret: string
     }
   }
 }

--- a/packages/bonde-public/next.config.js
+++ b/packages/bonde-public/next.config.js
@@ -29,7 +29,8 @@ module.exports = withCSS(withSass({
       domainApiRest: process.env.REACT_APP_DOMAIN_API_REST,
       domainApiGraphql: process.env.REACT_APP_DOMAIN_API_GRAPHQL,
       domainPublic: process.env.REACT_APP_DOMAIN_PUBLIC,
-      pagarmeKey: process.env.REACT_APP_PAGARME_KEY
+      pagarmeKey: process.env.REACT_APP_PAGARME_KEY,
+      hasuraSecret: process.env.REACT_APP_HASURA_SECRET
     }
   })
 )

--- a/packages/bonde-public/package.json
+++ b/packages/bonde-public/package.json
@@ -19,6 +19,7 @@
     "@zeit/next-sass": "^1.0.1",
     "apollo-cache-inmemory": "^1.6.2",
     "apollo-client": "^2.6.3",
+    "apollo-link-context": "^1.0.18",
     "apollo-link-http": "^1.5.15",
     "axios": "0.18.0",
     "bonde-webpage": "^0.14.7-alpha.0",

--- a/packages/bonde-public/src/apolloClient.ts
+++ b/packages/bonde-public/src/apolloClient.ts
@@ -1,19 +1,35 @@
 import 'isomorphic-fetch'
 import ApolloClient from 'apollo-client'
+import { ApolloLink } from 'apollo-link'
 import { createHttpLink } from 'apollo-link-http'
+import { setContext } from 'apollo-link-context'
 import getConfig from 'next/config'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 
 const { publicRuntimeConfig } = getConfig()
 
-const link = createHttpLink({
+const httpLink = createHttpLink({
   uri: publicRuntimeConfig.domainApiGraphql || 'http://api-v2.bonde.devel'
+})
+
+const authLink = setContext((_, { headers }) => {
+  const hasuraToken = publicRuntimeConfig.hasuraSecret || 'segredo123'
+
+  return {
+    headers: {
+      ...headers,
+      'x-hasura-admin-secret': hasuraToken
+    }
+  }
 })
 
 const cache = new InMemoryCache()
 
 export default new ApolloClient({
-  link,
+  link: ApolloLink.from([
+    authLink,
+  	httpLink
+  ]),
   cache,
   connectToDevTools: true
 })

--- a/packages/bonde-public/yarn.lock
+++ b/packages/bonde-public/yarn.lock
@@ -1168,6 +1168,14 @@ apollo-client@^2.6.3:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
+apollo-link-context@^1.0.18:
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.18.tgz#9e700e3314da8ded50057fee0a18af2bfcedbfc3"
+  integrity sha512-aG5cbUp1zqOHHQjAJXG7n/izeMQ6LApd/whEF5z6qZp5ATvcyfSNkCfy3KRJMMZZ3iNfVTs6jF+IUA8Zvf+zeg==
+  dependencies:
+    apollo-link "^1.2.12"
+    tslib "^1.9.3"
+
 apollo-link-http-common@^0.2.14:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz#d3a195c12e00f4e311c417f121181dcc31f7d0c8"


### PR DESCRIPTION
## Contexto
Para usar o Hasura API é necessário fazer uma autenticação básica, tanto para uso de metodo privados quanto públicos, foi preciso adaptar o cliente graphql para tratar dessa autenticação.

## Issues linkadas
- [ ] #1226

## Notas de deploy
- Configurar váriavel de ambiente `REACT_APP_DOMAIN_API_GRAPHQL` para endereço do Hasura API
- Configurar váriavel de ambiente `REACT_APP_HASURA_SECRET` com chave de acesso ao Hasura API

## Como testar?
-  Com ambiente configurado, configure uma mobilização com widget de doação (ele usa o GraphQL na hora de buscar os dados de doações, na barra de progresso).
- Deve ser possível visualizar as informações de doações pagas na barra de progresso do widget.
```
NOTA:
Você pode criar uma doação pelo formulário e alterar na base de dados o 
campo `transaction_status` para `paid`
```