### PR TITLE
Hotfix - Reset password form

### DIFF
--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
@@ -27,11 +27,11 @@ const ResetPasswordForm = ({ t, token }) => (
             changePasswordField
           }
         } = data
-
+        const user = { name: changePasswordField.userFirstName }
         return AuthAPI
           .login({ jwtToken: changePasswordField.token })
           .then(() => {
-            notify(t('resetPassword.success', { name: changePasswordField.userFirstName }))
+            notify(t('resetPassword.success', { user }))
             // should redirect with window to rehydrate session
             window.location.href = '/'
           })

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import qs from 'query-string'
 
 import { required, min } from 'services/validations'
 import { AuthAPI } from 'services/auth'
@@ -14,7 +13,7 @@ import { PasswordField } from '../../components'
 
 const formName = 'ResetPasswordForm'
 
-const ResetPasswordForm = ({ t, token, location }) => (
+const ResetPasswordForm = ({ t, token }) => (
   <Flexbox vertical>
     <Title.H2 margin={{ bottom: 18 }}>{t('resetPassword.form.title')}</Title.H2>
     <Title.H4 margin={{ bottom: 30 }}>{t('resetPassword.form.subtitle')}</Title.H4>
@@ -25,23 +24,16 @@ const ResetPasswordForm = ({ t, token, location }) => (
       onSuccess={({ data }) => {
         const {
           resetPasswordChangePassword: {
-            changePasswordField, newPassword
+            changePasswordField
           }
         } = data
-        if (data.resetPasswordChangePassword && !newPassword) {
-          // it's not an auth error
-          return Promise.reject({ form: t('form.authError') })
-        }
 
         return AuthAPI
           .login({ jwtToken: changePasswordField.token })
           .then(() => {
-            return notify(t('resetPassword.success', { name: changePasswordField.userFirstName }))
+            notify(t('resetPassword.success', { name: changePasswordField.userFirstName }))
             // should redirect with window to rehydrate session
-            const search = qs.parse(location.search)
-            if (search.next) {
-              window.location.href = search.next
-            } else { window.location.href = '/' }
+            window.location.href = '/'
           })
       }}
     >

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
@@ -2,18 +2,16 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { required, min } from 'services/validations'
-import { AuthAPI } from 'services/auth'
 import resetPassword from './resetPassword.graphql'
 
 import { Flexbox2 as Flexbox, Title } from 'bonde-styleguide'
 import { Field, MutationForm, SubmitButton } from 'components/Forms'
 import { ButtonLink } from 'components/Link'
-import { notify } from 'components/Notification'
 import { PasswordField } from '../../components'
 
 const formName = 'ResetPasswordForm'
 
-const ResetPasswordForm = ({ t, token }) => (
+const ResetPasswordForm = ({ t, token, handleSuccess }) => (
   <Flexbox vertical>
     <Title.H2 margin={{ bottom: 18 }}>{t('resetPassword.form.title')}</Title.H2>
     <Title.H4 margin={{ bottom: 30 }}>{t('resetPassword.form.subtitle')}</Title.H4>
@@ -21,17 +19,7 @@ const ResetPasswordForm = ({ t, token }) => (
       mutation={resetPassword}
       variables={{ token }}
       formId={formName}
-      onSuccess={({ data }) => {
-        const { changePasswordField } = data.resetPasswordChangePassword
-        const user = { name: changePasswordField.userFirstName }
-        return AuthAPI
-          .login({ jwtToken: changePasswordField.token })
-          .then(() => {
-            notify(t('resetPassword.success', { user }))
-            // should redirect with window to rehydrate session
-            window.location.href = '/'
-          })
-      }}
+      onSuccess={handleSuccess}
     >
       <Field
         name='password'

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
@@ -22,11 +22,7 @@ const ResetPasswordForm = ({ t, token }) => (
       variables={{ token }}
       formId={formName}
       onSuccess={({ data }) => {
-        const {
-          resetPasswordChangePassword: {
-            changePasswordField
-          }
-        } = data
+        const { changePasswordField } = data.resetPasswordChangePassword
         const user = { name: changePasswordField.userFirstName }
         return AuthAPI
           .login({ jwtToken: changePasswordField.token })

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/ResetPasswordForm/ResetPasswordForm.js
@@ -1,20 +1,39 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+
+import { required, min } from 'services/validations'
+import { AuthAPI } from 'services/auth'
+import resetPassword from './resetPassword.graphql'
+
 import { Flexbox2 as Flexbox, Title } from 'bonde-styleguide'
 import { Field, MutationForm, SubmitButton } from 'components/Forms'
 import { ButtonLink } from 'components/Link'
-import { required, min } from 'services/validations'
+import { notify } from 'components/Notification'
 import { PasswordField } from '../../components'
-import resetPassword from './resetPassword.graphql'
-import PropTypes from 'prop-types'
 
-const ResetPasswordForm = ({ t, token, handleSuccess }) => (
+const formName = 'ResetPasswordForm'
+
+const ResetPasswordForm = ({ t, token }) => (
   <Flexbox vertical>
     <Title.H2 margin={{ bottom: 18 }}>{t('resetPassword.form.title')}</Title.H2>
     <Title.H4 margin={{ bottom: 30 }}>{t('resetPassword.form.subtitle')}</Title.H4>
     <MutationForm
       mutation={resetPassword}
       variables={{ token }}
-      onSuccess={handleSuccess}
+      onSuccess={({ data }) => {
+        const { changePasswordField } = data.resetPasswordChangePassword
+        const user = { name: changePasswordField.userFirstName }
+
+        AuthAPI.login({
+          jwtToken: changePasswordField.token
+        })
+          .then(() => {
+            notify(t('resetPassword.success', { user }))
+            // should redirect with window to rehydrate session
+            window.location.href = '/'
+          })
+      }}
+      formId={formName}
     >
       <Field
         name='password'
@@ -28,7 +47,7 @@ const ResetPasswordForm = ({ t, token, handleSuccess }) => (
       />
       <Flexbox padding={{ top: 25 }} horizontal spacing='between'>
         <ButtonLink to='/auth/login'>{t('resetPassword.form.cancel')}</ButtonLink>
-        <SubmitButton>{t('resetPassword.form.submit')}</SubmitButton>
+        <SubmitButton title={t('resetPassword.form.submit')} formId={formName}>{t('resetPassword.form.submit')}</SubmitButton>
       </Flexbox>
     </MutationForm>
   </Flexbox>

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
@@ -8,7 +8,7 @@ import InvalidToken from './InvalidToken'
 import ResetPasswordForm from './ResetPasswordForm'
 import PropTypes from 'prop-types'
 
-const ResetPassword = ({ match, location }) => (
+const ResetPassword = ({ match }) => (
   <I18n ns='auth'>
     {t => {
       const token = match.params.token
@@ -24,7 +24,6 @@ const ResetPassword = ({ match, location }) => (
               <ResetPasswordForm
                 t={t}
                 token={token}
-                location={location}
               />
             )
           }}

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import { I18n } from 'react-i18next'
 import { Query } from 'react-apollo'
+import PropTypes from 'prop-types'
 
 import tokenVerify from './tokenVerify.graphql'
+
 import CheckingToken from './CheckingToken'
 import InvalidToken from './InvalidToken'
 import ResetPasswordForm from './ResetPasswordForm'
-import PropTypes from 'prop-types'
 
 const ResetPassword = ({ match }) => (
   <I18n ns='auth'>

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
@@ -2,7 +2,9 @@ import React from 'react'
 import { I18n } from 'react-i18next'
 import { Query } from 'react-apollo'
 import PropTypes from 'prop-types'
+import { notify } from 'components/Notification'
 
+import { AuthAPI } from 'services/auth'
 import tokenVerify from './tokenVerify.graphql'
 
 import CheckingToken from './CheckingToken'
@@ -25,6 +27,21 @@ const ResetPassword = ({ match }) => (
               <ResetPasswordForm
                 t={t}
                 token={token}
+                handleSuccess={({ data }) => {
+                  const {
+                    resetPasswordChangePassword: {
+                      changePasswordField
+                    }
+                  } = typeof data !== 'undefined' && data
+                  const user = { name: changePasswordField.userFirstName }
+                  return AuthAPI
+                    .login({ jwtToken: changePasswordField.token })
+                    .then(() => {
+                      notify(t('resetPassword.success', { user }))
+                      // should redirect with window to rehydrate session
+                      window.location.href = '/'
+                    })
+                }}
               />
             )
           }}

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
@@ -8,7 +8,7 @@ import InvalidToken from './InvalidToken'
 import ResetPasswordForm from './ResetPasswordForm'
 import PropTypes from 'prop-types'
 
-const ResetPassword = ({ match }) => (
+const ResetPassword = ({ match, location }) => (
   <I18n ns='auth'>
     {t => {
       const token = match.params.token
@@ -24,6 +24,7 @@ const ResetPassword = ({ match }) => (
               <ResetPasswordForm
                 t={t}
                 token={token}
+                location={location}
               />
             )
           }}

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
@@ -32,7 +32,7 @@ const ResetPassword = ({ match }) => (
                     resetPasswordChangePassword: {
                       changePasswordField
                     }
-                  } = typeof data !== 'undefined' && data
+                  } = data
                   const user = { name: changePasswordField.userFirstName }
                   return AuthAPI
                     .login({ jwtToken: changePasswordField.token })

--- a/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
+++ b/packages/bonde-admin-canary/src/scenes/Auth/scenes/ResetPassword/index.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import { I18n } from 'react-i18next'
 import { Query } from 'react-apollo'
-import { AuthAPI } from 'services/auth'
-import { notify } from 'components/Notification'
 
 import tokenVerify from './tokenVerify.graphql'
 import CheckingToken from './CheckingToken'
@@ -26,19 +24,6 @@ const ResetPassword = ({ match }) => (
               <ResetPasswordForm
                 t={t}
                 token={token}
-                handleSuccess={({ data }) => {
-                  const { changePasswordField } = data.resetPasswordChangePassword
-                  const user = { name: changePasswordField.userFirstName }
-
-                  AuthAPI.login({
-                    jwtToken: changePasswordField.token
-                  })
-                    .then(() => {
-                      notify(t('resetPassword.success', { user }))
-                      // should redirect with window to rehydrate session
-                      window.location.href = '/'
-                    })
-                }}
               />
             )
           }}


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
Problema levantado pela issue #1254 
Não é possivel inserir uma nova senha no input do formulário de reset de senha

## Checklist
-  [ ] Deve ser possivel informar uma nova senha
- [ ] Ao submeter a nova senha, o usuário deve ser direcionado para dentro da aplicação (home do admin-canary) já autenticado.
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [ ] Resolves #1254 
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->
Faça o processo de "esqueci minha senha", depois vá até a tela de `reset-password`. Ela fica em **admin-canary.bonde.devel/auth/reset-password/:token**
