### PR TITLE
Redirect user to `community/info` when clicking on community settings

### DIFF
--- a/packages/bonde-admin-canary/src/scenes/Dashboard/components/CommunityMenu.js
+++ b/packages/bonde-admin-canary/src/scenes/Dashboard/components/CommunityMenu.js
@@ -30,7 +30,14 @@ const menuBuilder = (menuName, { community, module }) => ({
   'settings': {
     icon: 'settings',
     component: ButtonLink,
-    to: `/admin/${community.id}/settings`
+    onClick: () => {
+      authSession
+        .setAsyncItem('community', community)
+        .then(() => {
+          const baseUrl = process.env.REACT_APP_DOMAIN_ADMIN || 'http://app.bonde.devel:5001'
+          window.open(`${baseUrl}/community/info`, '_blank')
+        })
+    }
   }
 })[menuName]
 
@@ -39,9 +46,7 @@ const CommunityMenu = ({ community, dark, pathname }) => {
 
   const menus = Object.keys(modules).map((moduleName) => {
     const module = modules[moduleName]
-    if (module) {
-      return menuBuilder(moduleName, { community, module })
-    }
+    if (module) return menuBuilder(moduleName, { community, module })
     return null
   }).filter(obj => !!obj)
 


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->
Redirecionar usuário que clica no ícone de configurações da comunidade para `/community/info` do bonde-admin

## Checklist
<!-- Descreva as principais alterações que este PR faz. -->
- [ ] Redireciona o usuário para as configurações da comunidade

## Issues linkadas
<!-- Adicione as respectivas issues linkadas a este PR. -->
- [ ] Resolves #1259 

## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->
Entre em http://admin-canary.bonde.devel:5002/, clicar no ícone de configurações de alguma comunidade e checar se você foi redirecionado para `/community/info` da comunidade correta