### PR TITLE
Order by results from last week

### DIFF
--- a/packages/redes-client/src/components/Header.tsx
+++ b/packages/redes-client/src/components/Header.tsx
@@ -6,61 +6,71 @@ import {
   SubHeader,
 } from "bonde-components";
 import { Link, useRouteMatch } from "react-router-dom";
+import { useFilterDispatch } from "../services/FilterProvider"
 
-const Header = (): React.ReactElement => (
-  <SubHeader>
-    <Heading.H3>Redes</Heading.H3>
-    <Navigation>
-      <Link to="/">
-        <Tab
-          active={
-            !!useRouteMatch({
-              path: "/",
-              exact: true,
-            })
-          }
+const Header = (): React.ReactElement => {
+  const dispatch = useFilterDispatch()
+  return (
+    <SubHeader>
+      <Heading.H3>Redes</Heading.H3>
+      <Navigation>
+        <Link to="/">
+          <Tab
+            active={
+              !!useRouteMatch({
+                path: "/",
+                exact: true,
+              })
+            }
+          >
+            Início
+          </Tab>
+        </Link>
+        <Link 
+          to="/pessoas" 
+          onClick={() => dispatch({ 
+            type: "order_by", 
+            value: [{ created_at: 'asc'}]
+          })}
         >
-          Início
-        </Tab>
-      </Link>
-      <Link to="/pessoas">
-        <Tab
-          active={
-            !!useRouteMatch({
-              path: "/pessoas",
-              exact: false,
-            })
-          }
-        >
-          Pessoas
-        </Tab>
-      </Link>
-      <Link to="/matches">
-        <Tab
-          active={
-            !!useRouteMatch({
-              path: "/matches",
-              exact: false,
-            })
-          }
-        >
-          Relações
-        </Tab>
-      </Link>
-      <Link to="/configuracoes/match">
-        <Tab
-          active={
-            !!useRouteMatch({
-              path: "/configuracoes/match",
-              exact: false,
-            })
-          }
-        >
-          Configurações
-        </Tab>
-      </Link>
-    </Navigation>
-  </SubHeader>
-);
+          <Tab
+            active={
+              !!useRouteMatch({
+                path: "/pessoas",
+                exact: false,
+              })
+            }
+          >
+            Pessoas
+          </Tab>
+        </Link>
+        <Link to="/matches">
+          <Tab
+            active={
+              !!useRouteMatch({
+                path: "/matches",
+                exact: false,
+              })
+            }
+          >
+            Relações
+          </Tab>
+        </Link>
+        <Link to="/configuracoes/match">
+          <Tab
+            active={
+              !!useRouteMatch({
+                path: "/configuracoes/match",
+                exact: false,
+              })
+            }
+          >
+            Configurações
+          </Tab>
+        </Link>
+      </Navigation>
+    </SubHeader>
+  )
+}
 
 export default Header;

--- a/packages/redes-client/src/components/WeeklyStats.tsx
+++ b/packages/redes-client/src/components/WeeklyStats.tsx
@@ -62,6 +62,10 @@ export default function WeeklyStats({
                     value: individualGroup?.id || 0,
                   },
                 });
+                dispatch({
+                  type: "order_by",
+                  value: [{ created_at: 'desc' }]
+                })
                 return dispatch({
                   type: "individuals",
                   value:
@@ -82,8 +86,12 @@ export default function WeeklyStats({
           </Link>
           <Link to="/matches">
             <StatsCard
-              onClick={() =>
+              onClick={() => {
                 dispatch({
+                  type: "order_by",
+                  value: [{ created_at: 'desc' }]
+                })
+                return dispatch({
                   type: "relationships",
                   value: {
                     relationshipStatus: getOption(
@@ -93,6 +101,7 @@ export default function WeeklyStats({
                   },
                 })
               }
+              }
             >
               <Header.H2>{encaminhamentosRealizados.aggregate.count}</Header.H2>
               <Text>Encaminhamentos Realizados</Text>
@@ -101,8 +110,12 @@ export default function WeeklyStats({
           {communityId === MAPA_DO_ACOLHIMENTO_COMMUNITY && (
             <Link to="/matches">
               <StatsCard
-                onClick={() =>
+                onClick={() => {
                   dispatch({
+                    type: "order_by",
+                    value: [{ created_at: 'desc' }]
+                  })
+                  return dispatch({
                     type: "relationships",
                     value: {
                       relationshipStatus: getOption(
@@ -111,7 +124,7 @@ export default function WeeklyStats({
                       ),
                     },
                   })
-                }
+                }}
               >
                 <Header.H2>
                   {encaminhamentosServicoPublico.aggregate.count}
@@ -122,8 +135,12 @@ export default function WeeklyStats({
           )}
           <Link to="/matches">
             <StatsCard
-              onClick={() =>
+              onClick={() => {
                 dispatch({
+                  type: "order_by",
+                  value: [{ updated_at: 'desc' }]
+                })
+                return dispatch({
                   type: "relationships",
                   value: {
                     relationshipStatus: getOption(
@@ -132,10 +149,10 @@ export default function WeeklyStats({
                     ),
                   },
                 })
-              }
+              }}
             >
               <Header.H2>{atendimentosIniciados.aggregate.count}</Header.H2>
-              <Text>Atendimento Iniciados</Text>
+              <Text>Atendimentos Iniciados</Text>
             </StatsCard>
           </Link>
           <Link to="/pessoas">
@@ -148,6 +165,10 @@ export default function WeeklyStats({
                     value: volunteerGroup?.id || 0,
                   },
                 });
+                dispatch({
+                  type: "order_by",
+                  value: [{ updated_at: 'desc' }]
+                })
                 return dispatch({
                   type: "individuals",
                   value: {
@@ -170,6 +191,10 @@ export default function WeeklyStats({
                     value: volunteerGroup?.id || 0,
                   },
                 });
+                dispatch({
+                  type: "order_by",
+                  value: [{ updated_at: 'desc' }]
+                })
                 return dispatch({
                   type: "individuals",
                   value: {

--- a/packages/redes-client/src/data/Mapa/FetchIndividuals.tsx
+++ b/packages/redes-client/src/data/Mapa/FetchIndividuals.tsx
@@ -9,13 +9,13 @@ const INDIVIDUALS_BY_GROUP = gql`
   query Individuals(
     $rows: Int!
     $offset: Int!
-    $order_by: [solidarity_tickets_order_by!]
     $userStatus: String_comparison_exp
     $relationshipStatus: String_comparison_exp
     $state: String_comparison_exp
     $availability: String_comparison_exp
     $individualId: bigint_comparison_exp
     $query: String
+    $order_by: [solidarity_tickets_order_by!]
   ) {
     data: solidarity_tickets(
       where: {
@@ -63,7 +63,9 @@ const INDIVIDUALS_BY_GROUP = gql`
 `;
 
 const FetchIndividuals = (props: any = {}) => {
-  const { individuals, rows, offset, selectedGroup } = useFilterState();
+  const { 
+    individuals, rows, offset, selectedGroup, order_by 
+  } = useFilterState();
 
   const {
     userStatus,
@@ -92,9 +94,7 @@ const FetchIndividuals = (props: any = {}) => {
     },
     rows,
     offset,
-    // created_at: {
-    //   _eq: created_at,
-    // };
+    order_by: order_by || [{ created_at: 'asc' }]
   };
 
   return (

--- a/packages/redes-client/src/data/Mapa/FetchMatches.tsx
+++ b/packages/redes-client/src/data/Mapa/FetchMatches.tsx
@@ -13,14 +13,13 @@ const MATCHES = gql`
     $state: String_comparison_exp
     $agent: bigint_comparison_exp
     $query: String
-    $created_at: timestamp_comparison_exp
+    $order_by: [solidarity_matches_order_by!]
   ) {
     relationships: solidarity_matches(
       limit: $rows
       offset: $offset
-      order_by: { created_at: desc }
+      order_by: $order_by
       where: {
-        created_at: $created_at
         status: $status
         recipient_ticket: { assignee_id: $agent }
         recipient: { state: $state }
@@ -36,7 +35,6 @@ const MATCHES = gql`
       individualsTicketId: individuals_ticket_id
       volunteersTicketId: volunteers_ticket_id
       relationshipStatus: status
-      createdAt: created_at
       recipientTicket: recipient_ticket {
         agentId: assignee_id
       }
@@ -49,7 +47,6 @@ const MATCHES = gql`
     }
     relationshipsCount: solidarity_matches_aggregate(
       where: {
-        created_at: $created_at
         status: $status
         recipient_ticket: { assignee_id: $agent }
         recipient: { state: $state }
@@ -70,7 +67,7 @@ const MATCHES = gql`
 `;
 
 const FetchMatches = (props: any = {}) => {
-  const { relationships, rows, offset } = useFilterState();
+  const { relationships, rows, offset, order_by } = useFilterState();
 
   const { relationshipStatus, state, query, agent } = getSelectValues(
     relationships
@@ -89,9 +86,7 @@ const FetchMatches = (props: any = {}) => {
     query: `%${query || ""}%`,
     rows,
     offset,
-    // created_at: {
-    //   _eq: created_at,
-    // };
+    order_by: order_by || [{ created_at: 'asc' }]
   };
 
   return (

--- a/packages/redes-client/src/data/Redes/FetchIndividuals.tsx
+++ b/packages/redes-client/src/data/Redes/FetchIndividuals.tsx
@@ -15,6 +15,7 @@ export const INDIVIDUALS_BY_GROUP = gql`
     $availability: String_comparison_exp
     $redeGroupId: Int_comparison_exp
     $query: String
+    $order_by: [rede_individuals_order_by!]
   ) {
     data: rede_individuals(
       where: {
@@ -33,7 +34,7 @@ export const INDIVIDUALS_BY_GROUP = gql`
       }
       limit: $rows
       offset: $offset
-      order_by: { created_at: asc }
+      order_by: $order_by
     ) {
       ...individual
     }
@@ -59,7 +60,9 @@ export const INDIVIDUALS_BY_GROUP = gql`
 `;
 
 const FetchIndividuals = (props: any = {}) => {
-  const { individuals, rows, offset, selectedGroup } = useFilterState();
+  const { 
+    individuals, rows, offset, selectedGroup, order_by 
+  } = useFilterState();
 
   const { userStatus, availability, state, query } = getSelectValues(
     individuals
@@ -83,7 +86,8 @@ const FetchIndividuals = (props: any = {}) => {
     offset,
     context: {
       _eq: props.community && props.community.id
-    }
+    },
+    order_by: order_by || [{ created_at: 'asc' }]
   };
 
   return (

--- a/packages/redes-client/src/data/Redes/FetchMatches.tsx
+++ b/packages/redes-client/src/data/Redes/FetchMatches.tsx
@@ -14,11 +14,12 @@ export const MATCHES = gql`
     $state: String_comparison_exp
     $agent: Int_comparison_exp
     $query: String
+    $order_by: [rede_relationships_order_by!]
   ) {
     relationships: rede_relationships(
       limit: $rows
       offset: $offset
-      order_by: { created_at: desc }
+      order_by: $order_by
       where: {
         recipient: { group: { community_id: $context }, state: $state }
         user_id: $agent
@@ -76,7 +77,7 @@ export const MATCHES = gql`
 `;
 
 const FetchMatches = ({ community, ...props }: any) => {
-  const { relationships, rows, offset } = useFilterState();
+  const { relationships, rows, offset, order_by } = useFilterState();
 
   const { relationshipStatus, state, agent, query } = getSelectValues(
     relationships
@@ -96,6 +97,7 @@ const FetchMatches = ({ community, ...props }: any) => {
     query: `%${query || ""}%`,
     rows,
     offset,
+    order_by: order_by || [{ created_at: 'asc' }]
   };
 
   return (

--- a/packages/redes-client/src/services/FilterProvider.tsx
+++ b/packages/redes-client/src/services/FilterProvider.tsx
@@ -8,10 +8,12 @@ export type Pagination = {
   rows: number;
   offset: number;
   page: number;
+  order_by: Array<Record<string, 'asc' | 'desc'>>
 };
 
 type Action =
   | { type: "page"; value: number }
+  | { type: "order_by"; value: Array<Record<string, 'asc' | 'desc'>> }
   | { type: "rows"; value: number }
   | { type: "group"; value: { value: number; label: string } | null }
   | { type: "relationships"; value: any }
@@ -44,13 +46,13 @@ const initialFilters = {
   agent: undefined,
   state: undefined,
   availability: undefined,
-  // created_at: undefined,
 };
 
 const initialState = {
   rows: 10,
   offset: 10 * 0,
   page: 0,
+  order_by: undefined,
   selectedGroup: undefined,
   relationships: initialFilters,
   individuals: initialFilters,
@@ -77,6 +79,12 @@ function filterReducer(state: State, action: Action) {
         rows: action.value,
         offset: action.value * state.page,
       };
+    }
+    case "order_by": {
+      return {
+        ...state,
+        order_by: action.value
+      }
     }
     case "group": {
       return {


### PR DESCRIPTION
- Order results by 'desc' when user clicks in the Weekly Data cards and goes to `/pessoas` or `/matches`
- Order by 'asc' when user click directly to the tab (original behaviour)