### PR TITLE
Hotfix/domain form

### DIFF
--- a/clients/packages/canary-client/src/scenes/Community/Domains/CreateDomainModal/DomainForm.tsx
+++ b/clients/packages/canary-client/src/scenes/Community/Domains/CreateDomainModal/DomainForm.tsx
@@ -51,7 +51,7 @@ const isDomain = (value: any) => /(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-
 const DomainForm = ({ onSubmit, onClose }: Props) => {
   return (
     <ConnectedForm onSubmit={onSubmit}>
-      {({ submiting, dirty, submitError }: any) => (
+      {({ submiting, dirty, submitError, valid }: any) => (
         <Container fluid style={{ width: '100%', padding: '0' }}>
           <Row style={{ marginBottom: '24px' }}>
             <Col xs={12}>
@@ -66,13 +66,15 @@ const DomainForm = ({ onSubmit, onClose }: Props) => {
           <Row style={{ marginBottom: '20px' }}>
             <Col xs={12}>
               <Text><b>Já tem um domínio?</b> Então adicione ele aqui:</Text>
+              <Text><b>Obs:</b> Não é permitido caracteres especiais!</Text>
+
               <AddOn>
                 <InputField
                   label='http://www.'
                   name='value'
                   type='text'
                   validate={composeValidators(
-                    required('Preencha o dominio'),
+                    required('Preencha o domínio'),
                     isDomain
                   )}
                 />
@@ -89,7 +91,9 @@ const DomainForm = ({ onSubmit, onClose }: Props) => {
               <Link style={{ cursor: 'pointer' }} onClick={onClose}>Cancelar</Link>
             </Col>
             <Col xs={6} style={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <Button disabled={submiting || !dirty} type='submit'>Continuar</Button>
+              <Button disabled={!valid || submiting || !dirty} type='submit'>
+                Continuar
+              </Button>
             </Col>
           </Row>
         </Container>

--- a/clients/packages/canary-client/src/scenes/Community/Domains/CreateDomainModal/DomainForm.tsx
+++ b/clients/packages/canary-client/src/scenes/Community/Domains/CreateDomainModal/DomainForm.tsx
@@ -46,7 +46,7 @@ type Props = {
 
 const { composeValidators, required } = Validators;
 
-const isDomain = (value: any) => /(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]/.test(value) ? undefined : ' X ';
+const isDomain = (value: any) => /[\w][^A-Zç!'(?=*[}{,^?~=+\_\/*+\|]+\.[^A-Z][\w]{1,}(\.[\w]{1,})?/g.test(value) ? undefined : ' X ';
 
 const DomainForm = ({ onSubmit, onClose }: Props) => {
   return (
@@ -66,7 +66,7 @@ const DomainForm = ({ onSubmit, onClose }: Props) => {
           <Row style={{ marginBottom: '20px' }}>
             <Col xs={12}>
               <Text><b>Já tem um domínio?</b> Então adicione ele aqui:</Text>
-              <Text><b>Obs:</b> Não é permitido caracteres especiais!</Text>
+              <Text><b>Obs:</b> Não é permitido letras maiúsculas e caracteres especiais!</Text>
 
               <AddOn>
                 <InputField

--- a/workers/documents/tsconfig.json
+++ b/workers/documents/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
+      "typeRoots": ["node_modules/@types"],
+      "lib": ["dom", "es2020"],
       "module": "commonjs",
       "esModuleInterop": true,
       "target": "es6",
@@ -8,8 +10,7 @@
       "sourceMap": true,
       "outDir": "dist",
       "baseUrl": ".",
-      "lib": ["es2020"],
-      "paths": {
+        "paths": {
         "*": [
           "node_modules/*",
           "src/types/*"


### PR DESCRIPTION
## Contexto
Ao configurar um domínio não é permitido usar caracteres especiais, acentos e nem letras maiúsculas, porém a plataforma não avisa sobre essa regra nos campos de configuração e isso resulta num gargalo no momento da certificação. 

## Checklist
- [x] Desabilitar botão quando houver caracteres especiais no domínio
- [x] Adicionar observação em texto alertando sobre o uso de caracteres especiais e letras maiúsculas
- [x] Atualiza regex para rejeitar caracteres especiais e letras maiúsculas no domínio, mantendo o uso de hífen e números. 

obs: as alterações do arquivo tsconfig.json são as que permitiram, no meu ambiente, a execução do script que gera certificados.
