### PR TITLE
fix: direct link to correct community domains page

### DIFF
--- a/clients/deprecated/admin/packages/bonde-admin/src/community/paths.js
+++ b/clients/deprecated/admin/packages/bonde-admin/src/community/paths.js
@@ -1,8 +1,13 @@
+import urljoin from 'url-join';
+
 const namespace = '/community'
+const adminCanaryDomains = () => {
+    window.location.href = urljoin(process.env.REACT_APP_DOMAIN_ADMIN_CANARY, '/community/domains')
+}
 
 export const communityAdd = () => `/communities/new`
 export const communityDomain = () => `${namespace}/domain`
-export const communityDomainCreate = next => `${namespace}/domain/add${next || ''}`
+export const communityDomainCreate = next => `${adminCanaryDomains()}`
 export const communityDomainEdit = domain => `${namespace}/domain/${domain.id}/edit`
 export const communityInfo = () => `${namespace}/info`
 export const communityList = () => `/communities`


### PR DESCRIPTION
## Contexto
Nas Configurações da Página, na aba Domínios, o texto de instrução tem um link que direciona para o admin antigo

## Checklist
- [x] Permitir que o link do texto de instrução seja direcionada para uma url diferente: a de domínios da comunidade do admin-canary