### PR TITLE
Hotfix Settings Widget Form

### DIFF
--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Adjusts/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Adjusts/index.tsx
@@ -9,12 +9,15 @@ import SettingsForm from '../SettingsForm';
 import RadioField, { Radio } from '../../../../components/Radio';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const AdjustsFields = ({ widget }: any) => {
+const AdjustsFields = ({ widget, updateCache }: any) => {
   const { t } = useTranslation('widgetActions');
 
   return (
     <SettingsForm
       widget={widget}
+      afterSubmit={async (values:any, result:any) => {
+        updateCache(result.data.update_widgets.returning[0])
+      }}
       initialValues={{
         settings: {
           show_city: "city-false",

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
@@ -15,16 +15,20 @@ import SettingsForm from '../SettingsForm';
 
 type Props = {
   widget: Widget;
+  updateCache: any;
 };
 
 const { required, composeValidators, isEmail } = Validators;
 
-const AutofireForm = ({ widget }: Props): React.ReactElement => {
+const AutofireForm = ({ widget, updateCache }: Props): React.ReactElement => {
   const { t } = useTranslation("widgetActions");
 
   return (
     <SettingsForm
       widget={widget}
+      afterSubmit={async (values:any, result:any) => {
+        updateCache(result.data.update_widgets.returning[0])
+      }}
       initialValues={{
         settings: widget.settings
       }}

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/ConfigurePostAction/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/ConfigurePostAction/index.tsx
@@ -14,9 +14,10 @@ import RichInputField from "./RichInputField";
 
 type Props = {
 	widget: Widget;
+	updateCache: any;
 };
 
-const ConfigurePostAction = ({ widget }: Props): React.ReactElement => {
+const ConfigurePostAction = ({ widget, updateCache }: Props): React.ReactElement => {
 	const { t } = useTranslation("widgetActions");
 
 	// Parse older finish messages saved like text
@@ -29,6 +30,9 @@ const ConfigurePostAction = ({ widget }: Props): React.ReactElement => {
 	return (
 		<SettingsForm
 			widget={widget}
+			afterSubmit={async (values:any, result:any) => {
+        updateCache(result.data.update_widgets.returning[0])
+      }}
 			initialValues={{
 				settings: {
 					...widget.settings,

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Sending/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Sending/index.tsx
@@ -15,9 +15,10 @@ import { Flex } from "../Sending/Flex";
 
 type Props = {
 	widget: Widget;
+	updateCache: any;
 };
 
-const ConfirmModal = ({ defaultIsOpen, onCancel }: any) => {
+const ConfirmModal = ({ defaultIsOpen, onCancel}: any) => {
 	const [isOpen, setIsOpen] = useState(defaultIsOpen);
 
 	// useEffect serve para determinar que a propriedade 
@@ -61,12 +62,15 @@ const ConfirmModal = ({ defaultIsOpen, onCancel }: any) => {
 	);
 }
 
-const Sending = ({ widget }: Props): React.ReactElement => {
+const Sending = ({ widget, updateCache }: Props): React.ReactElement => {
 	const { t } = useTranslation("widgetActions");
 
 	return (
 		<SettingsForm
 			widget={widget}
+			afterSubmit={async (values:any, result:any) => {
+        updateCache(result.data.update_widgets.returning[0])
+      }}
 			initialValues={{
 				settings: {
 					optimization_enabled: true,

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/SettingsForm.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/SettingsForm.tsx
@@ -15,6 +15,10 @@ const UpdateWidgetGQL = gql`
       _append: { settings: $settings }
     ) {
       affected_rows
+      returning {
+        id
+        settings
+      }
     }
   }
 `;

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/SettingsForm.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/SettingsForm.tsx
@@ -54,9 +54,18 @@ const SettingsForm = ({ children, widget, initialValues, afterSubmit, ...connect
   const { t } = useTranslation('widgetActions');
 
   const onSubmit = async ({ primaryKey, settings, ...values }: SubmitProps) => {
+    const newSettings: any = {}
+    Object.keys(initialValues.settings).forEach((key: string) => {
+      if (Object.keys(settings).filter((key2) => key2 === key).length === 0) {
+        newSettings[key] = ""
+      }
+    });
+    const mergeSettings = {
+      ...settings,
+      ...newSettings
+    }
+    const result = await save({ variables: { primaryKey, settings: mergeSettings } });
     try {
-      const result = await save({ variables: { primaryKey, settings } });
-
       if (!(result.data.update_widgets.affected_rows === 1)) {
         throw new Error(t('settings.defaultForm.error'));
       }
@@ -65,7 +74,7 @@ const SettingsForm = ({ children, widget, initialValues, afterSubmit, ...connect
         type: toast.TYPE.SUCCESS,
       });
 
-      if (afterSubmit) await afterSubmit({ primaryKey, settings, ...values }, result);
+      if (afterSubmit) await afterSubmit({ primaryKey, settings: mergeSettings, ...values }, result);
 
     } catch (e) {
       console.log(e);

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/index.tsx
@@ -33,7 +33,7 @@ const Settings = ({ widgets }: Props) => {
 
   const updateCache = (updated: Widget) => {
 
-    setWidgetsCached(widgets.map((w: Widget) => w.id === updated.id ? updated : w));
+    setWidgetsCached(widgets.map((w: Widget) => w.id === updated.id ? {...w, ...updated} : w));
   }
 
   return (
@@ -88,16 +88,16 @@ const Settings = ({ widgets }: Props) => {
               )}
             </Route>
             <Route exact path={`${match.path}/sending`}>
-              <Sending widget={widget}/>
+              <Sending widget={widget} updateCache={updateCache}/>
             </Route>
             <Route exact path={`${match.path}/adjusts`}>
-              <Adjusts widget={widget} />
+              <Adjusts widget={widget} updateCache={updateCache}/>
             </Route>
             <Route exact path={`${match.path}/autofire`}>
-              <Autofire widget={widget} />
+              <Autofire widget={widget} updateCache={updateCache}/>
             </Route>
             <Route exact path={`${match.path}/finish`}>
-              <ConfigurePostAction widget={widget} />
+              <ConfigurePostAction widget={widget} updateCache={updateCache}/>
             </Route>
           </Switch>
         </Col>


### PR DESCRIPTION
## Contexto
Ao fazer alguma modificação nas configurações de pressão e salvar, a plataforma sinaliza que as alterações foram salvas, mas ao trocar de aba e voltar, as alterações somem. As novas alterações só voltam aparecer se a página for atualizada, mostrando que o problema não está em salvar as alterações, mas sim em apresentá-las ao usuário.

## Checklist
- [x] Adiciona propriedade que permite a visualização das alterações salvas em todas as abas
- [x] Corrigir problema para campos que podem ser vazio (https://github.com/final-form/react-final-form/issues/430)