### PR TITLE
Feature/sendgrid integration v2

### DIFF
--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Performance/StepByStepCard.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Performance/StepByStepCard.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Stack, Box, Heading, Text, Button } from "bonde-components";
+import { useHistory, useLocation } from "react-router-dom";
+
+const StepByStepCard: React.FC = () => {
+  const location = useLocation();
+  const history = useHistory();
+  const pushPath = ((path: string) => {
+    history.push(location.pathname + path)
+  })
+
+  return (
+    <Stack
+      direction="row"
+      bg="white"
+      height={60}
+      spacing={[98, 98, 98, 158]}
+      padding={38}
+    >
+      <Stack maxW={60} justifyContent="center" >
+        <Heading size="4xl">
+          Bora pressionar!
+        </Heading>
+
+        <Text fontSize="18px">
+          Para começar, lembre-se de:
+        </Text>
+      </Stack>
+
+      <Stack direction="row" spacing={45} >
+        <Box maxW={60}>
+          <Text fontSize="18px">
+            1 - Definir os <b>alvos</b> da sua campanha (quem você quer pressionar) e o conteúdo do e-mail que será enviado para eles;
+          </Text>
+
+          <Button variant="ghost" justifyContent="left" onClick={() => pushPath("/targets")}>Definir alvos</Button>
+        </Box>
+
+        <Box maxW={60}>
+          <Text fontSize="18px">
+            2 - Ajustar o <b>formulário</b> para deixá-lo do jeitinho da sua campanha;
+          </Text>
+
+          <Button variant="ghost" justifyContent="left" onClick={() => pushPath("/adjusts")} >Ajustar formulário</Button>
+        </Box>
+
+        <Box maxW={60}>
+          <Text fontSize="18px">
+            3 - Escrever o <b>e-mail de agradecimento</b> que vai ser enviado para quem agir na sua campanha.
+          </Text>
+
+          <Button variant="ghost" justifyContent="left" onClick={() => pushPath("/autofire")}>Escrever e-mail</Button>
+        </Box>
+      </Stack>
+    </Stack >
+  )
+}
+
+export default StepByStepCard;

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Performance/TargetsStatistics.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Performance/TargetsStatistics.tsx
@@ -37,9 +37,27 @@ const OpenedLabel: React.FC<{ activityFeed: ActivityFeedEmail }> = ({ activityFe
   )
 }
 
-const FailedLabel: React.FC<{ activityFeed: ActivityFeedEmail }> = ({ activityFeed }) => {
+const StatusLabel: React.FC<{ activityFeed: ActivityFeedEmail }> = ({ activityFeed }) => {
+  const isDelivered = activityFeed.events.filter((evt) => evt.eventType === "delivered").length > 0;
   const isFailed = activityFeed.events.filter((evt) => evt.eventType === "bounce").length > 0;
   const isDropped = activityFeed.events.filter((evt) => evt.eventType === "dropped").length > 0;
+
+  if (isDelivered) {
+    return (
+      <Tooltip
+        label="Pelo menos um e-mail foi entregue com sucesso na caixa de entrada do alvo."
+        maxW="220px"
+      >
+        <Button
+          variant="tag"
+          colorScheme="green"
+          textTransform="none"
+          fontWeight="400">
+          Entregue
+        </Button>
+      </Tooltip>
+    )
+  }
 
   if (isFailed) {
     return (
@@ -129,7 +147,7 @@ const TargetsStatistics: React.FC<Props> = ({ aggregateEmails, activeTargets }) 
             <Th>Email</Th>
             <Th>Enviados</Th>
             <Th>Entregues</Th>
-            <Th>Falha</Th>
+            <Th>Status</Th>
             <Th>Abertura</Th>
           </Tr>
         </Thead>
@@ -163,7 +181,7 @@ const TargetsStatistics: React.FC<Props> = ({ aggregateEmails, activeTargets }) 
                     {`${deliveredPercentage}% entregue`}
                   </Td>
                   <Td>
-                    <FailedLabel activityFeed={activityFeed} />
+                    <StatusLabel activityFeed={activityFeed} />
                   </Td>
                   <Td>
                     <OpenedLabel activityFeed={activityFeed} />

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Performance/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Performance/index.tsx
@@ -8,6 +8,7 @@ import DisclaimerRelease from "./DisclaimerRelease";
 import usePerformance from "./hooks/usePerformance";
 import Card from "./Card";
 import TargetsTable from "./TargetsTable";
+import StepByStepCard from "./StepByStepCard";
 
 type Props = {
   widget: Widget
@@ -45,6 +46,7 @@ const PerformanceScene: React.FC<Props> = ({ widget }) => {
   } = data;
 
   const hasntEventHistory = firstEventTimestamp > widgetCreatedAt && aggregateEvents.length === 0;
+  const hasntPressure = pressuresCount === 0 && activeTargets.length === 0;
 
   return (
     <Stack spacing={6}>
@@ -54,6 +56,11 @@ const PerformanceScene: React.FC<Props> = ({ widget }) => {
           widgetCreatedAt={widgetCreatedAt}
         />
       )}
+      {
+        hasntPressure && (
+          <StepByStepCard />
+        )
+      }
       <Stack direction="row" spacing={4}>
         <BondePressureCards targetsCount={activeTargets.length} pressuresCount={pressuresCount} />
         {!hasntEventHistory && (

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Performance/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Performance/index.tsx
@@ -46,7 +46,7 @@ const PerformanceScene: React.FC<Props> = ({ widget }) => {
   } = data;
 
   const hasntEventHistory = firstEventTimestamp > widgetCreatedAt && aggregateEvents.length === 0;
-  const hasntPressure = pressuresCount === 0 && activeTargets.length === 0;
+  const hasntPressure = pressuresCount === 0;
 
   return (
     <Stack spacing={6}>


### PR DESCRIPTION
## Contexto
1- Como mobilizador, quando criar uma nova pressão quero ver o passo a passo para facilitar a experiência de configuração da ferramenta de pressão.

2- Como mobilizador, quero ver a coluna de status do envio dos emails para cada alvo para verificar rapidamente quem está sendo atingido pela minha campanha.

## Checklist
- [x] Atualizar a coluna "falha" para a de "status" e incluir a tag "entregue" quando não houver falha nem bloqueio.
- [x] Em widgets sem registros de eventos/pressão, mostrar passo a passo para facilitar a experiência de configuração da ferramenta de pressão.