### PR TITLE
Corrigi estilos do slate-editor na edição da mobilização

### DIFF
--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/index.scss
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/index.scss
@@ -36,3 +36,20 @@
 .editor--content.editable table > tbody >tr > td {
   border-right: 1px solid black;
 }
+
+@import url('./styles/ImageEditLayer.module.scss');
+@import url('./styles/ImageNode.module.scss');
+@import url('./styles/Modal.module.css');
+@import url('./styles/ModalButton.module.css');
+@import url('./styles/ModalContent.module.css');
+@import url('./styles/ModalForm.module.css');
+@import url('./styles/Tooltip.module.css');
+@import url('./styles/ColorButton.module.css');
+@import url('./styles/DraggableColorPicker.module.css');
+@import url('./styles/AlignmentButtonBar.module.css');
+@import url('./styles/EmbedButton.module.css');
+@import url('./styles/EmbedNode.module.css');
+@import url('./styles/FontSizeInput.module.css');
+@import url('./styles/GridButtonBar.module.css');
+@import url('./styles/LinkNode.module.css');
+@import url('./styles/ListButtonBar.module.css');

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/AlignmentButtonBar.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/AlignmentButtonBar.module.css
@@ -1,0 +1,3 @@
+.slate-alignment-plugin--button-bar {
+  display: inline-block;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ColorButton.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ColorButton.module.css
@@ -1,0 +1,3 @@
+.slate-color-plugin--toolbar {
+  display: inline-block;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/DraggableColorPicker.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/DraggableColorPicker.module.css
@@ -1,0 +1,30 @@
+.slate-color-plugin--draggable-handle-container {
+  position: absolute;
+  z-index: 9;
+  box-sizing: border-box;
+}
+
+.slate-color-plugin--draggable-handle {
+  content: '';
+  width: 100px;
+  height: 7px;
+  position: absolute;
+  left: 50%;
+  top: 1px;
+  z-index: 1;
+  border-top: 1px solid #999;
+  border-bottom: 1px solid #999;
+  margin-left: -50px;
+  cursor: all-scroll;
+  box-sizing: border-box;
+}
+.slate-color-plugin--draggable-handle:after {
+  content: '';
+  height: 3px;
+  width: 100%;
+  position: absolute;
+  top: 1px;
+  border-top: 1px solid #999;
+  border-bottom: 1px solid #999;
+  box-sizing: border-box;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/EmbedButton.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/EmbedButton.module.css
@@ -1,0 +1,5 @@
+.slate-embed-plugin--button[data-active="true"] {
+  box-shadow: 0 0 5px 1px rgba(0,0,0,.3);
+  z-index: 1;
+  position: relative;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/EmbedNode.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/EmbedNode.module.css
@@ -1,0 +1,9 @@
+.slate-embed-plugin--node {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.slate-embed-plugin--node.active {
+  border: 3px solid #0275d8;
+  margin: -3px 0;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/FontSizeInput.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/FontSizeInput.module.css
@@ -1,0 +1,3 @@
+.slate-font-size-plugin-input {
+  width: 79px;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/GridButtonBar.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/GridButtonBar.module.css
@@ -1,0 +1,3 @@
+.slate-grid-plugin--button-bar {
+  display: inline-block;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ImageEditLayer.module.scss
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ImageEditLayer.module.scss
@@ -1,0 +1,50 @@
+.image-node--container .image-node--image-edit-layer,
+.image-node--container .image-node--image-edit-layer:active,
+.image-node--container .image-node--image-edit-layer:focus {
+  display: none;
+  justify-content: center;
+  align-items: center;
+  content: '';
+  width: 100%;
+  height: calc(100% - 6px);
+  position: absolute;
+  left: 0;
+  top: 0;
+  background-color: rgba(255,255,255,.5);
+  z-index: 10;
+  cursor: pointer;
+  outline: 3px solid #1f78d8;
+  box-shadow: 0 0 12px #1f78d8;
+}
+.image-node--container .image-node--image-edit-layer .image-node--image-edit-button {
+  z-index: 11;
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.9);
+  border-radius: 3px;
+  border: none;
+  font-size: 12px;
+  padding: 7px 10px;
+  text-align: center;
+  cursor: pointer;
+  position: relative;
+  z-index: 11;
+  line-height: 1;
+}
+.image-node--container .image-node--image-edit-layer .image-node--image-edit-text {
+  color: #000;
+  font-size: 14px;
+  padding: 7px 10px;
+  text-align: center;
+  position: relative;
+  line-height: 1;
+  font-weight: 600;
+}
+
+.image-node--container:not(.readonly):hover .image-node--image-edit-layer,
+.image-node--container:not(.readonly):hover .image-node--image-edit-button {
+  display: flex;
+}
+
+.image-node--container.readonly .image-node--image-edit-button {
+  display: none;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ImageNode.module.scss
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ImageNode.module.scss
@@ -1,0 +1,19 @@
+.editor--content > div > div {
+  position: initial !important;
+}
+
+
+.image-node--container {
+  display: inline-block;
+  position: relative;
+}
+
+
+.image-node {
+  max-width: 100%;
+  position: relative;
+}
+
+.image-node.selected {
+  border: 3px dotted blue;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/LinkNode.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/LinkNode.module.css
@@ -1,0 +1,3 @@
+.link-node-container {
+  position: relative;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ListButtonBar.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ListButtonBar.module.css
@@ -1,0 +1,3 @@
+.slate-list-plugin--button-bar {
+  display: inline-block;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/Modal.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/Modal.module.css
@@ -1,0 +1,77 @@
+/**
+ * Layer
+ */
+.modal--layer {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255,255,255,.8);
+  left: 0;
+  top: 0;
+  z-index: 12;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/**
+ * Modal
+ */
+.modal--container {
+  background-color: #fff;
+  width: 768px;
+  box-shadow: 0 0 50px rgba(120,120,120,.3);
+}
+
+/**
+ * Modal Header
+ */
+.modal--container .modal--header {
+  padding: 30px;
+  border-bottom: 1px solid #efefef;
+  text-align: left;
+  color: #000;
+}
+
+/**
+ * Close Button
+ */
+.modal--container .modal--header .button--close {
+  float: right;
+  border: none;
+  background-color: transparent;
+  position: relative;
+  outline: none;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+}
+
+.modal--container .modal--header .button--close::before,
+.modal--container .modal--header .button--close::after {
+  content: '';
+  position: absolute;
+  width: 20px;
+  height: 2px;
+  background-color: #ccc;
+  right: 0;
+  top: 8px;
+}
+
+.modal--container .modal--header .button--close:hover::before,
+.modal--container .modal--header .button--close:hover::after {
+  background-color: #aaa;
+}
+
+.modal--container .modal--header .button--close::before {
+  transform: rotate(45deg)
+}
+.modal--container .modal--header .button--close::after {
+  transform: rotate(-45deg)
+}
+
+@media screen and (max-width: 768px) {
+  .modal--container {
+    width: 100%;
+  }
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ModalButton.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ModalButton.module.css
@@ -1,0 +1,54 @@
+/**
+ * Modal Button: Container
+ */
+.modal--container .modal--content .modal-button--container {
+  text-align: left;
+}
+
+/**
+ * Modal Button
+ */
+.modal--container .modal--content .modal-button--container button {
+  border: none;
+  border-radius: 3px;
+  background-color: transparent;
+  padding: 10px 18px;
+  font-size: 15px;
+  font-weight: 500;
+  margin-right: 10px;
+  cursor: pointer;
+}
+
+/**
+ * Modal Button: Primary
+ */
+.modal--container .modal--content .modal-button--container button.primary {
+  background-color: #0B83F5;
+  color: #fff;
+}
+.modal--container .modal--content .modal-button--container button.primary:hover {
+  background-color: #096fd0;
+}
+
+/**
+ * Modal Button: Opaque
+ */
+.modal--container .modal--content .modal-button--container button.opaque {
+  background-color: #EEEEEE;
+}
+.modal--container .modal--content .modal-button--container button.opaque:hover {
+  background-color: #E4E4E4;
+}
+
+/**
+ * Modal Button: Danger
+ */
+.modal--container .modal--content .modal-button--container button.danger {
+  border: 2px solid #F43A35;
+  color: #F43A35;
+  margin-left: 20px;
+}
+.modal--container .modal--content .modal-button--container button.danger:hover {
+  background-color: #F43A35;
+  color: #FFFFFF;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ModalContent.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ModalContent.module.css
@@ -1,0 +1,32 @@
+/**
+ * Modal Content
+ */
+.modal--container .modal--content {
+  padding: 30px 40px;
+  display: flex;
+  justify-content: space-between;
+}
+
+/**
+ * Modal Content: Left
+ */
+.modal--container .modal--content .modal--content-left {
+  width: 30%;
+  position: relative;
+}
+
+/**
+ * Modal Content: Right
+ */
+.modal--container .modal--content .modal--content-right {
+  width: 65%;
+  margin-left: 5%;
+}
+
+/**
+ * Modal Content: Image Adjust
+ */
+.modal--container .modal--content .modal--content-left img,
+.modal--container .modal--content .modal--content-right img {
+  max-width: 100%;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ModalForm.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/ModalForm.module.css
@@ -1,0 +1,37 @@
+/**
+ * Modal Form: Group
+ */
+.modal--container .modal--form .modal--form-group {
+  margin-bottom: 30px;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal--container .modal--form .modal--form-group label {
+  font-family: 'Century Gothic', 'Lucida Sans Unicode', sans-serif, Verdana, Arial;
+  font-size: 14px;
+  margin-bottom: 10px;
+  color: #333;
+  text-align: left;
+}
+
+.modal--container .modal--form .modal--form-group input {
+  border-radius: 3px;
+  outline: none;
+  box-shadow: none;
+  border: 1px solid #dfdfdf;
+  padding: 10px;
+  font-size: 16px;
+}
+
+.modal--container .modal--form .modal--form-group input::placeholder {
+  color: #ccc;
+}
+
+.modal--container .modal--form .modal--form-label-helper {
+  font-size: .75rem;
+  color: #999;
+  margin-bottom: .5rem;
+  line-height: 1rem;
+  text-align: left;
+}

--- a/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/Tooltip.module.css
+++ b/clients/packages/admin-client/src/mobilizations/widgets/__plugins__/content/components/editor-slate/styles/Tooltip.module.css
@@ -1,0 +1,61 @@
+/**
+ * Tooltip
+ */
+.tooltip--container {
+  display: none;
+  position: absolute;
+  left: 0;
+  bottom: -55px;
+  font-family: 'Trebuchet MS', 'Helvetica Neue', Helvetica, Tahoma, sans-serif;
+  background-color: rgba(0,0,0,.95);
+  color: #555;
+  font-size: 14px;
+  padding: 16px;
+  border-radius: 3px;
+  min-width: 275px;
+  max-height: 290px;
+  text-align: left;
+  user-select: none;
+  z-index: 1;
+}
+
+/**
+ * Tooltip Item
+ */
+.tooltip--container .tooltip--item {
+  display: inline-block;
+  font-size: 14px;
+  color: #ccc;
+  text-decoration: none;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+  border-left:  1px solid #555;
+  padding:  0 10px;
+  cursor: pointer;
+}
+.tooltip--container .tooltip--item:first-of-type {
+  border: none;
+}
+.tooltip--container .tooltip--item:hover,
+.tooltip--container .tooltip--item:active,
+.tooltip--container .tooltip--item:focus {
+  color: #fff;
+}
+
+/**
+ * Tooltip Item: Link Adjusts
+ */
+.tooltip--container .tooltip--item > a,
+.tooltip--container .tooltip--item > a:visited {
+  text-decoration: none;
+  color: #ccc;
+}
+
+.tooltip--container .tooltip--item > a:hover,
+.tooltip--container .tooltip--item > a:active,
+.tooltip--container .tooltip--item > a:focus {
+  color: #fff;
+}


### PR DESCRIPTION
Deve ser possivel editar Widget de Conteúdo com manipulando imagens, links e outras funcionalidades implementadas na barra de ferramentas sem quebrar seu estilo.