### PR TITLE
feat(canary): Add button to copy invitation link;

### DIFF
--- a/clients/packages/canary-client/public/locales/en/community.json
+++ b/clients/packages/canary-client/public/locales/en/community.json
@@ -192,6 +192,10 @@
         }
       },
       "actions": {
+        "copy": {
+          "success": "Invitation Link copied successfully",
+          "label": "Copy Link"
+        },
         "resend": {
           "success": "Invitation resent successfully",
           "label": "Resent"

--- a/clients/packages/canary-client/public/locales/pt-BR/community.json
+++ b/clients/packages/canary-client/public/locales/pt-BR/community.json
@@ -192,6 +192,10 @@
         }
       },
       "actions": {
+        "copy": {
+          "success": "Link p/ Convite copiado com sucesso",
+          "label": "Copiar Link"
+        },
         "resend": {
           "success": "Convite reenviado com sucesso",
           "label": "Reenviar"

--- a/clients/packages/canary-client/src/scenes/Community/Mobilizers/InvitationsTable.tsx
+++ b/clients/packages/canary-client/src/scenes/Community/Mobilizers/InvitationsTable.tsx
@@ -5,13 +5,14 @@ import { useTranslation } from 'react-i18next';
 import Table, { Styles } from './Table';
 import Role from './Role';
 import Resend from './Resend';
+import Reseted from './Reseted';
 import 'moment/locale/pt-br';
 
-type Row = {
+export type Row = {
   original: any
 }
 
-type RowProps = {
+export type RowProps = {
   row: Row
 }
 
@@ -66,6 +67,11 @@ function App({ data: defaultData, refetch }: Props) {
         Header: <Header.H5>{t('mobilizers.table.columns.expires.header')}</Header.H5>,
         accessor: 'expires',
         Cell: Expired(refetch)
+      },
+      {
+        Header: <Header.H5>Ações</Header.H5>,
+        accessor: 'user.reset_password_token',
+        Cell: Reseted(t)
       }
     ],
     [refetch, t]

--- a/clients/packages/canary-client/src/scenes/Community/Mobilizers/Reseted.tsx
+++ b/clients/packages/canary-client/src/scenes/Community/Mobilizers/Reseted.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { toast } from 'bonde-components'
+import { Button } from 'bonde-components/chakra';
+import copy from 'clipboard-copy';
+import { RowProps } from './InvitationsTable'
+
+const Reseted = (t: any) => ({ row: { original: data } }: RowProps) => {
+    const token = data.user.reset_password_token;
+
+    const copyLink = () => {
+        copy(`${process.env.REACT_APP_DOMAIN_ACCOUNTS}/reset-password?token=${token}`);
+        return toast(t('mobilizers.table.actions.copy.success'), { type: toast.TYPE.SUCCESS });
+    }
+
+    return token ? <Button href="#" onClick={copyLink} colorScheme="gray" variant="tableLink">{t('mobilizers.table.actions.copy.label')}</Button> : <></>
+}
+
+export default Reseted;

--- a/clients/packages/canary-client/src/scenes/Community/Mobilizers/index.tsx
+++ b/clients/packages/canary-client/src/scenes/Community/Mobilizers/index.tsx
@@ -18,6 +18,7 @@ const InvitationsQuery = gql`
         user {
           first_name
           email
+          reset_password_token
         }
         created_at
         role


### PR DESCRIPTION
Na página de mobilizadores da comunidade, dentro da aba de convites foi adicionado uma coluna de ações com a possibilidade de cópia do link do convite nos casos que o convite ainda for válido. 

É exibido uma mensagem de sucesso ao copiar o link, como pode ser visto na imagem.

Foi adicionado tradução para inglês e português.

TODO
- [ ] Add tests to Reseted component

![image](https://user-images.githubusercontent.com/14948/163037877-01f365e9-563e-410d-b51f-436c4cda59a0.png)
