### PR TITLE
fix(canary): change pagination to pages info

### DIFF
--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/Pagination.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/Pagination.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Button,
+  Text,
   Flex,
   FormControl,
   Stack,
@@ -21,6 +22,7 @@ const ArrowRightIcon = createIcon({
 })
 
 interface Props {
+  loading?: boolean;
   onChangePage: (pageIndex: number) => void;
   onPreviousPage: () => void;
   onNextPage: () => void;
@@ -30,7 +32,8 @@ interface Props {
 }
 
 const Pagination: React.FC<Props> = ({
-  onChangePage,
+  // onChangePage,
+  loading,
   onChangeLimit,
   onPreviousPage,
   onNextPage,
@@ -63,7 +66,8 @@ const Pagination: React.FC<Props> = ({
       >
         <ArrowLeftIcon />
       </Button>
-      {Array.from({ length: pages + 1 }, (_: any, key: number) => (
+      <Text fontWeight="bold">{!loading ? `${pageIndex + 1} de ${pages + 1}` : "..."}</Text>
+      {/* {Array.from({ length: pages + 1 }, (_: any, key: number) => (
         <Button
           variant='outline'
           colorScheme="gray"
@@ -72,8 +76,8 @@ const Pagination: React.FC<Props> = ({
           disabled={pageIndex === key}
         >
           {key + 1}
-        </Button>  
-      ))}
+        </Button>
+      ))} */}
       <Button
         variant='outline'
         colorScheme="gray"

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/TableView.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/TableView.tsx
@@ -69,6 +69,7 @@ const PlipsFormTable: React.FC<any> = ({ widgetId }) => {
       <Table variant="simple" bg="white">
         <TableCaption>
           <Pagination
+            loading={loading}
             onChangePage={onChangePage}
             onChangeLimit={onChangeLimit}
             onPreviousPage={onPreviousPage}


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->

Ao paginar listas com muitos elementos, as páginas representadas como botões acabam estourando a tela, para resolver esse problema estamos alterando os botãos para um texto informativo sobre indice atual e quantidade total de páginas.
