### PR TITLE
fix(admin): remove options to generate mobilization by template

### DIFF
--- a/clients/packages/admin-client/src/mobrender/redux/action-creators/async-update-mobilization.ts
+++ b/clients/packages/admin-client/src/mobrender/redux/action-creators/async-update-mobilization.ts
@@ -57,6 +57,50 @@ export const UPDATE_MOBILIZATION_QUERY = gql`
   }
 `;
 
+export const UPDATE_MOBILIZATION_ONLY_QUERY = gql`
+  mutation ($id: Int!, $input: mobilizations_set_input) {
+    update_mobilizations_by_pk(
+      pk_columns: { id: $id },
+      _set: $input
+    ) {
+      id
+      body_font
+      color_scheme
+      created_at
+      custom_domain
+      deleted_at
+      facebook_share_description
+      facebook_share_image
+      facebook_share_title
+      favicon
+      goal
+      google_analytics_code
+      header_font
+      language
+      name
+      slug
+      status
+      twitter_share_text
+      updated_at
+      user_id
+      community {
+        id
+        name
+      }
+      mobilizations_subthemes {
+        subtheme {
+          id
+          label
+        }
+      }
+      theme {
+        id
+        label
+      }
+    }
+  }
+`;
+
 interface Values extends Record<string, any> {
   subthemes?: number[]
   id: number;
@@ -65,13 +109,19 @@ interface Values extends Record<string, any> {
 
 export default ({ fieldName, id, subthemes, ...values }: Values) => (dispatch): Promise<any> => {
   dispatch(createAction(t.UPDATE_MOBILIZATION_REQUEST));
+  const requestPromise = (subthemes || []).length > 0
+    ? graphQLClient.request(UPDATE_MOBILIZATION_QUERY, {
+        id,
+        input: values,
+        subthemes: subthemes?.map((subtheme_id) => ({ mobilization_id: id, subtheme_id }))
+      })
+    : graphQLClient.request(UPDATE_MOBILIZATION_QUERY, {
+        id,
+        input: values,
+        subthemes: subthemes?.map((subtheme_id) => ({ mobilization_id: id, subtheme_id }))
+      })
 
-  return graphQLClient.request(UPDATE_MOBILIZATION_QUERY, {
-    id,
-    input: values,
-    subthemes: subthemes?.map((subtheme_id) => ({ mobilization_id: id, subtheme_id }))
-  })
-  .then((data) => {
+  return requestPromise.then((data) => {
     dispatch(createAction(t.UPDATE_MOBILIZATION_SUCCESS, data.update_mobilizations_by_pk));
     
     if (values.template_mobilization_id) {

--- a/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose/page.connected.js
+++ b/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose/page.connected.js
@@ -20,6 +20,7 @@ const mapStateToProps = (state, props) => ({
 
 const mapActionsToProps = (dispatch, props) => ({
   createMobilizationFromTemplate: ({ mobilization, template }) => {
+    console.log("createMobilizationFromTemplate", { mobilization, template });
     dispatch(
       asyncUpdateMobilization({
         id: mobilization.id,
@@ -30,6 +31,7 @@ const mapActionsToProps = (dispatch, props) => ({
     });
   },
   createEmptyMobilization: ({ mobilization }) => {
+    console.log("createEmptyMobilization", { mobilization });
     props.history.push(paths.createBlock(mobilization));
   },
 });

--- a/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose/page.js
+++ b/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose/page.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import * as paths from '../../../../../paths';
+// import * as paths from '../../../../../paths';
 import {
   BrowsableList,
   BrowsableListItem,
@@ -14,17 +14,19 @@ class TemplatesChoosePage extends Component {
     const {
       mobilization,
       loading,
-      customTemplatesLength,
+      // customTemplatesLength,
       globalTemplates,
-      createMobilizationFromTemplate,
+      // createMobilizationFromTemplate,
       createEmptyMobilization,
       location,
     } = this.props;
 
     if (loading) return <Loading />;
 
-    const renderEmptyChoice =
-      customTemplatesLength === 0 && globalTemplates.length === 0;
+    // const renderEmptyChoice =
+    //   customTemplatesLength === 0 && globalTemplates.length === 0;
+
+    console.log("globalTemplates", { globalTemplates });
 
     return (
       <PageTabLayout {...{ location }}>
@@ -36,21 +38,19 @@ class TemplatesChoosePage extends Component {
             />
           </h3>
           <BrowsableList>
-            {renderEmptyChoice && (
-              <BrowsableListItem
-                title={
-                  <FormattedMessage
-                    id="page--mobilizations.templates-choose.browsable-list-item.blank"
-                    defaultMessage="Criar mobilização do zero"
-                  />
-                }
-                leftIcon="plus-square-o"
-                onClick={() => {
-                  createEmptyMobilization({ mobilization });
-                }}
-              />
-            )}
-            {globalTemplates &&
+            <BrowsableListItem
+              title={
+                <FormattedMessage
+                  id="page--mobilizations.templates-choose.browsable-list-item.blank"
+                  defaultMessage="Criar mobilização do zero"
+                />
+              }
+              leftIcon="plus-square-o"
+              onClick={() => {
+                createEmptyMobilization({ mobilization });
+              }}
+            />
+            {/* {globalTemplates &&
               globalTemplates.map((template) => (
                 <BrowsableListItem
                   title={template.name}
@@ -71,7 +71,7 @@ class TemplatesChoosePage extends Component {
               leftIcon="columns"
               subtitle={customTemplatesLength}
               path={paths.mobilizationTemplatesChooseCustomList(mobilization)}
-            />
+            /> */}
           </BrowsableList>
         </div>
       </PageTabLayout>


### PR DESCRIPTION
## Contexto
Com a mudança realizada na comunicação com a API para possibilitar adicionar Mobilização com Temas, a funciona de Mobilização a partir de Template parou de funcionar.

Para não bloquear a criação de Mobilização, estamos adicionando essa correção que remove momentaneamente a possibilidade de criar uma Mobilização a partir de Templates.

### Alterações
- fix(admin): remove options to generate mobilization by template