### PR TITLE
fix(admin): change rules to async update mobilization on graphql

### DIFF
--- a/clients/packages/admin-client/src/mobrender/redux/action-creators/async-fetch-mobilizations.ts
+++ b/clients/packages/admin-client/src/mobrender/redux/action-creators/async-fetch-mobilizations.ts
@@ -6,7 +6,7 @@ const graphQLClient = new GraphQLClient(process.env.REACT_APP_DOMAIN_API_GRAPHQL
 
 export const FETCH_MOBILIZATIONS_QUERY = gql`
   query ($where: mobilizations_bool_exp) {
-    mobilizations(where: $where) {
+    mobilizations(where: $where, order_by: { updated_at: desc }) {
       id
       body_font
       color_scheme

--- a/clients/packages/admin-client/src/mobrender/redux/action-creators/async-update-mobilization-with-template.js
+++ b/clients/packages/admin-client/src/mobrender/redux/action-creators/async-update-mobilization-with-template.js
@@ -1,0 +1,40 @@
+/* eslint-disable prefer-promise-reject-errors */
+import { createAction } from './create-action'
+import * as t from '../action-types'
+import AuthSelectors from '../../../account/redux/selectors';
+
+import asyncFetchBlocks from './async-fetch-blocks'
+import asyncFetchWidgets from './async-fetch-widgets'
+
+export default ({ fieldName, ...mobilization }) =>
+  (dispatch, getState, { api }) => {
+      const headers = AuthSelectors(getState()).getCredentials();
+    const endpoint = `/mobilizations/${mobilization.id}`
+    const config = { headers }
+
+    dispatch({ type: t.UPDATE_MOBILIZATION_REQUEST })
+    return api
+      .put(endpoint, { mobilization }, config)
+      .then(({ status, data }) => {
+        dispatch({ type: t.UPDATE_MOBILIZATION_SUCCESS, payload: data })
+        if (mobilization.template_mobilization_id) {
+          dispatch(asyncFetchBlocks(data.id))
+          dispatch(asyncFetchWidgets(data.id))
+        }
+        return Promise.resolve(data)
+      })
+      .catch(({ response, ...errors }) => {
+        if (response.status === 422 && response.data.errors) {
+          const errors = response.data.errors
+          if (response.data.errors.custom_domain) {
+            errors[fieldName] = errors.custom_domain
+            delete errors.custom_domain
+          }
+          dispatch(createAction(t.UPDATE_MOBILIZATION_FAILURE, errors))
+          return Promise.reject({ ...errors })
+        } else {
+          dispatch(createAction(t.UPDATE_MOBILIZATION_FAILURE, errors))
+          return Promise.reject({ error: `Response code ${errors}` })
+        }
+      })
+  }

--- a/clients/packages/admin-client/src/mobrender/redux/action-creators/index.js
+++ b/clients/packages/admin-client/src/mobrender/redux/action-creators/index.js
@@ -30,3 +30,5 @@ export { default as selectMobilization } from './select-mobilization'
 export { default as selectWidget } from './select-widget'
 export { default as toggleMobilizationMenu } from './toggle-mobilization-menu'
 export { default as asyncFilterMobilization } from './async-filter-mobilization'
+
+export { default as asyncUpdateMobilizationWithTemplate } from './async-update-mobilization-with-template';

--- a/clients/packages/admin-client/src/mobrender/redux/selectors.spec.ts
+++ b/clients/packages/admin-client/src/mobrender/redux/selectors.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { fromJS } from 'immutable';
 
-import { reducer as rootReducer } from '../../mobrender/redux';
+import redux from '../../mobrender/redux';
 import Selectors from '../../mobrender/redux/selectors';
 
-const state = fromJS({
-  mobilizations: rootReducer,
+const state: any = fromJS({
+  mobilizations: redux.reducer,
 });
 
 describe('mobrender/redux/selectors', () => {

--- a/clients/packages/admin-client/src/mobrender/redux/selectors.ts
+++ b/clients/packages/admin-client/src/mobrender/redux/selectors.ts
@@ -24,10 +24,10 @@ export default (state?: any, props?: any) => ({
     return state.mobilizations.list.menuActiveIndex
   },
 
-  getMobilizations: (f) => {
+  getMobilizations: (filter?: any) => {
     const { list: { data } } = state.mobilizations
-    if (f && f.status) {
-      return data.filter(m => m.status === f.status)
+    if (filter && filter.status) {
+      return data.filter(m => m.status === filter.status)
     }
     return data.filter(m => m.status === 'active')
   },

--- a/clients/packages/admin-client/src/mobrender/redux/selectors.ts
+++ b/clients/packages/admin-client/src/mobrender/redux/selectors.ts
@@ -1,6 +1,9 @@
-export default (state, props) => ({
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { Mobilization } from "../types"
 
-  getMobilization: () => {
+export default (state?: any, props?: any) => ({
+
+  getMobilization: (): Mobilization | undefined => {
     const { list: { currentId: id, data } } = state.mobilizations
     return id ? data.filter(mob => mob.id === id)[0] : undefined
   },

--- a/clients/packages/admin-client/src/mobrender/types.ts
+++ b/clients/packages/admin-client/src/mobrender/types.ts
@@ -1,0 +1,39 @@
+export interface Community {
+  id: number;
+  name: string;
+}
+
+export interface Theme {
+  id: number;
+  label: string;
+}
+
+export interface MobilizationSubtheme {
+  subtheme: Theme
+}
+
+export interface Mobilization {
+  id: number;
+  body_font?: string;
+  color_scheme?: string;
+  created_at: string;
+  custom_domain?: string;
+  deleted_at?: string;
+  facebook_share_description?: string;
+  facebook_share_image?: string;
+  facebook_share_title?: string;
+  favicon?: string;
+  goal: string;
+  google_analytics_code?: string;
+  header_font?: string;
+  language?: string;
+  name: string;
+  slug: string;
+  status: string;
+  twitter_share_text?: string;
+  updated_at: string;
+  user_id: number;
+  community: Community
+  mobilizations_subthemes: MobilizationSubtheme[]
+  theme: Theme
+}

--- a/clients/packages/admin-client/src/pages/admin/mobilizations/settings/basics/page.connected.js
+++ b/clients/packages/admin-client/src/pages/admin/mobilizations/settings/basics/page.connected.js
@@ -17,7 +17,7 @@ const form = 'mobilizationBasicsForm';
 
 const mapStateToProps = (state, props) => {
   const mobilization = MobSelectors(state, props).getMobilization();
-  console.log("mobilization", { mobilization });
+
   return {
     formName: form,
     initialValues: {

--- a/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose-custom/page.connected.js
+++ b/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose-custom/page.connected.js
@@ -26,7 +26,7 @@ const mapStateToProps = (state, props) => ({
 const mapActionsToProps = {
   setFilterableSearchBarList,
   setSelectedIndex: SelectableActions.setSelectedIndex,
-  createMobilizationFromTemplate: MobActions.asyncUpdateMobilization,
+  createMobilizationFromTemplate: MobActions.asyncUpdateMobilizationWithTemplate,
 };
 
 const FETCH_TEMPLATES = gql`

--- a/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose/page.connected.js
+++ b/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose/page.connected.js
@@ -6,7 +6,7 @@ import { gql, useQuery } from 'bonde-core-tools';
 import { connect } from 'react-redux';
 import * as CommunitySelectors from '../../../../../community/selectors';
 import MobSelectors from '../../../../../mobrender/redux/selectors';
-import { asyncUpdateMobilization } from '../../../../../mobrender/redux/action-creators';
+import { asyncUpdateMobilizationWithTemplate } from '../../../../../mobrender/redux/action-creators';
 import * as TemplateSelectors from '../../../../../mobilizations/templates/selectors';
 import * as paths from '../../../../../paths';
 import Page from './page';
@@ -20,9 +20,8 @@ const mapStateToProps = (state, props) => ({
 
 const mapActionsToProps = (dispatch, props) => ({
   createMobilizationFromTemplate: ({ mobilization, template }) => {
-    console.log("createMobilizationFromTemplate", { mobilization, template });
     dispatch(
-      asyncUpdateMobilization({
+      asyncUpdateMobilizationWithTemplate({
         id: mobilization.id,
         template_mobilization_id: template.id,
       })

--- a/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose/page.js
+++ b/clients/packages/admin-client/src/pages/admin/mobilizations/templates/choose/page.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-// import * as paths from '../../../../../paths';
+import * as paths from '../../../../../paths';
 import {
   BrowsableList,
   BrowsableListItem,
@@ -14,19 +14,17 @@ class TemplatesChoosePage extends Component {
     const {
       mobilization,
       loading,
-      // customTemplatesLength,
+      customTemplatesLength,
       globalTemplates,
-      // createMobilizationFromTemplate,
+      createMobilizationFromTemplate,
       createEmptyMobilization,
       location,
     } = this.props;
 
     if (loading) return <Loading />;
 
-    // const renderEmptyChoice =
-    //   customTemplatesLength === 0 && globalTemplates.length === 0;
-
-    console.log("globalTemplates", { globalTemplates });
+    const renderEmptyChoice =
+      customTemplatesLength === 0 && globalTemplates.length === 0;
 
     return (
       <PageTabLayout {...{ location }}>
@@ -38,19 +36,21 @@ class TemplatesChoosePage extends Component {
             />
           </h3>
           <BrowsableList>
-            <BrowsableListItem
-              title={
-                <FormattedMessage
-                  id="page--mobilizations.templates-choose.browsable-list-item.blank"
-                  defaultMessage="Criar mobilização do zero"
-                />
-              }
-              leftIcon="plus-square-o"
-              onClick={() => {
-                createEmptyMobilization({ mobilization });
-              }}
-            />
-            {/* {globalTemplates &&
+            {renderEmptyChoice && (
+              <BrowsableListItem
+                title={
+                  <FormattedMessage
+                    id="page--mobilizations.templates-choose.browsable-list-item.blank"
+                    defaultMessage="Criar mobilização do zero"
+                  />
+                }
+                leftIcon="plus-square-o"
+                onClick={() => {
+                  createEmptyMobilization({ mobilization });
+                }}
+              />
+            )}
+            {globalTemplates &&
               globalTemplates.map((template) => (
                 <BrowsableListItem
                   title={template.name}
@@ -71,7 +71,7 @@ class TemplatesChoosePage extends Component {
               leftIcon="columns"
               subtitle={customTemplatesLength}
               path={paths.mobilizationTemplatesChooseCustomList(mobilization)}
-            /> */}
+            />
           </BrowsableList>
         </div>
       </PageTabLayout>


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
Atualizar mobilizações com temas tem sido um problema na API GraphQL, pois temas está modelado em uma tabela `many-to-many` então atualizar requer a manutenção dessas relações, essa atualização tem objetivo de só executar a chamada na mutation com temas quando realmente for necessário, nos demais casos ela executa uma mutation mais simples que envolve apenas atualização da tabela `mobilizations`

## Atualizações
- Metódo para atualizar mobilizações
- Metódo para atualizar mobilizações a partir dos templates