### PR TITLE
Feature/certificate screen

### DIFF
--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.spec.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.spec.tsx
@@ -1,19 +1,27 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Heading, Text } from 'bonde-components/chakra';
-import { CertificateStatus } from './CertificateStatus';
+import { Button, Heading, Text } from 'bonde-components/chakra';
 import LoadingIcon from '../../../icons/LoadingIcon';
+import { CertificateStatus } from './CertificateStatus';
+
+const authenticateSpy = jest.fn((values: any) => ({ data: {} }));
+
+jest.mock('bonde-core-tools', () => ({
+  useMutation: () => [authenticateSpy],
+  gql: jest.fn()
+}));
 
 describe("CertificateStatus tests", () => {
   const defaultMessage = 'Pode levar até 5 minutos para o certificado ser gerado e o endereço ficar disponível.';
-  const activeMessage = ["O endereço ", <b>nossas.link</b>, " está ativo e com certificado de segurança."];
+  const activeMessage = ["O endereço ", <b>www.nossas.link</b>, " está ativo e com certificado de segurança."];
+  const activeMessage2 = ["O endereço ", <b>www.nova-pagina.nossas.link</b>, " está ativo e com certificado de segurança."];
   const inactiveMessage = 'Inativo';
-  const loadingMessage = 'Gerando certificado'
   const failedMessage = 'Ops, falta configurar o ip'
 
   it('should renders is ok', () => {
     const wrapper = shallow(<CertificateStatus />);
     expect(wrapper).toBeTruthy();
+
   });
 
   it('should render default/inactive status message', () => {
@@ -22,6 +30,7 @@ describe("CertificateStatus tests", () => {
     expect(wrapper.find(Heading).props().children).toEqual('Status');
     expect(wrapper.find(Text).at(0).props().children).toEqual(inactiveMessage);
     expect(wrapper.find(Text).at(1).props().children).toEqual(defaultMessage);
+
   });
 
   it('should render message when certificate is in progress', () => {
@@ -33,7 +42,7 @@ describe("CertificateStatus tests", () => {
     const wrapper = shallow(<CertificateStatus customDomain={customDomain} hostedZones={hostedZones} />);
 
     expect(wrapper.find(LoadingIcon).at(0));
-    expect(wrapper.find(Text).at(0).props().children).toEqual(loadingMessage);
+    expect(wrapper.find(Text).at(0));
   });
 
   it('should render active status', () => {
@@ -71,7 +80,8 @@ describe("CertificateStatus tests", () => {
 
     expect(wrapper.find(Heading).props().children).toEqual('Status');
     expect(wrapper.find(Text).at(0).props().children).toEqual('Ativo');
-    expect(wrapper.find(Text).at(1).props().children).toEqual(activeMessage);
+    expect(wrapper.find(Text).at(1).props().children).toEqual(activeMessage2);
+
   });
 
   it('should render when ip is failed', () => {
@@ -84,5 +94,9 @@ describe("CertificateStatus tests", () => {
 
     expect(wrapper.find(LoadingIcon).at(0));
     expect(wrapper.find(Text).at(0).props().children).toEqual(failedMessage);
+    expect(wrapper.find(Button));
+
+    const button = wrapper.find(Button);
+    button.simulate('click');
   })
 });

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.spec.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Heading, Text } from 'bonde-components/chakra';
-import CertificateStatus from './CertificateStatus';
+import { CertificateStatus } from './CertificateStatus';
 import LoadingIcon from '../../../icons/LoadingIcon';
 
 describe("CertificateStatus tests", () => {

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
-import { Heading, Text, Stack, Flex } from 'bonde-components/chakra';
+import { Heading, Text, Stack, Flex, Button, useToast } from 'bonde-components/chakra';
 import CheckIcon from "../../../icons/CheckIcon"
 import LoadingIcon from "../../../icons/LoadingIcon"
+import { gql, useMutation, checkDNS } from 'bonde-core-tools';
+
+const IP_LISTS = [
+  '54.85.56.248',
+  '3.236.227.166'
+]
 
 interface Certificate {
   id: number;
@@ -33,6 +39,37 @@ const CertificateStatus: React.FC<Properties> = ({ customDomain, hostedZones = [
   const hasCertificate = domain?.certificates[0]?.is_active
   const isExternalDomain = domain?.is_external_domain
   const failedIp = !domain?.ns_ok && isExternalDomain
+  const toast = useToast()
+
+  const [updateDnsHostedZone] = useMutation(
+    gql`
+      mutation ($id: Int!) {
+        update_dns_hosted_zones_by_pk(
+          pk_columns: { id: $id }, _set: { ns_ok: true }
+        ) {
+          id
+          domain_name
+          ns_ok
+        }
+      }
+    `
+  );
+
+  //TODO: update domain para atualizar o estado da aplicação
+
+  const handleCheckDns = async (updateDomain: any) => {
+
+    if (await checkDNS(domain.domain_name, 'A', { ip: IP_LISTS })) {
+      await updateDnsHostedZone({
+        variables: {
+          id: domain.id // "A" verifica por IP
+        }
+      })
+      toast({ title: 'IP propagado!', status: 'success', duration: 4000, isClosable: true })
+    } else {
+      toast({ title: 'IP não propagado!', status: 'error', duration: 4000, isClosable: true })
+    }
+  }
 
   return (
     <Stack mt={6}>
@@ -66,16 +103,21 @@ const CertificateStatus: React.FC<Properties> = ({ customDomain, hostedZones = [
             <CheckIcon />
             <Text fontSize="sm" color="green.200" fontWeight="bold" textTransform="uppercase">Ativo</Text>
           </Flex>
-          <Text>O endereço <b>{domain?.domain_name}</b> está ativo e com certificado de segurança.</Text>
+          <Text>O endereço <b>{customDomain}</b> está ativo e com certificado de segurança.</Text>
         </>
       )}
 
       {/* FALTOU CONFIGURAR IP */}
       {failedIp && (
-        <Flex >
-          <LoadingIcon />
-          <Text fontSize="sm" fontWeight="bold" ml={2} textTransform="uppercase" color="gray.400">Ops, falta configurar o ip</Text>
-        </Flex>
+        <>
+          <Flex >
+            <LoadingIcon />
+            <Text fontSize="sm" fontWeight="bold" ml={2} textTransform="uppercase" color="gray.400">Ops, falta configurar o ip</Text>
+          </Flex>
+          <Text>Siga o passo a passo acima e <Button variant='link' textTransform='lowercase' onClick={handleCheckDns}
+          >clique aqui
+          </Button> para verificar novamente.</Text>
+        </>
       )}
     </Stack>
   );

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.tsx
@@ -41,7 +41,7 @@ export const CertificateStatus: React.FC<Properties> = ({ updateDomain, customDo
   )[0];
   const hasCertificate = domain?.certificates[0]?.is_active
   const isExternalDomain = domain?.is_external_domain
-  const failedIp = (!domain?.ns_ok && isExternalDomain) || (domain === undefined)
+  const failedIp = (!domain?.ns_ok && isExternalDomain) || (domain === undefined && customDomain)
   const toast = useToast()
 
   const [updateDnsHostedZone] = useMutation(

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.tsx
@@ -73,9 +73,9 @@ export const CertificateStatus: React.FC<Properties> = ({ updateDomain, customDo
         }
       );
 
-      toast({ title: 'IP propagado!', status: 'success', duration: 4000, isClosable: true });
+      toast({ title: 'Tudo certo!', description: 'Ip verificado', status: 'success', duration: 4000, isClosable: true });
     } else {
-      toast({ title: 'IP não propagado!', status: 'error', duration: 4000, isClosable: true })
+      toast({ title: 'Ops, IP não verificado', description: 'Aguarde mais alguns minutos e tente novamente', status: 'error', duration: 4000, isClosable: true })
     }
   }
 

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/CertificateStatus.tsx
@@ -41,7 +41,7 @@ export const CertificateStatus: React.FC<Properties> = ({ updateDomain, customDo
   )[0];
   const hasCertificate = domain?.certificates[0]?.is_active
   const isExternalDomain = domain?.is_external_domain
-  const failedIp = !domain?.ns_ok && isExternalDomain
+  const failedIp = (!domain?.ns_ok && isExternalDomain) || (domain === undefined)
   const toast = useToast()
 
   const [updateDnsHostedZone] = useMutation(
@@ -94,7 +94,7 @@ export const CertificateStatus: React.FC<Properties> = ({ updateDomain, customDo
       )}
 
       {/* GERANDO CERTIFICADO  */}
-      {customDomain && domain.ns_ok && !domain?.certificates[0]?.is_active && (
+      {customDomain && domain?.ns_ok && !domain?.certificates[0]?.is_active && (
         <>
           <Flex >
             <LoadingIcon />

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.spec.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.spec.tsx
@@ -95,13 +95,11 @@ describe('FormPanel tests', () => {
   describe('onSubmit validate', () => {
     const mockUpdateMobilization = jest.fn();
     const mockCreateDnsHostedZone = jest.fn();
-    const mockUpdateDnsHostedZone = jest.fn();
     const mockCreateOrUpdateCertificate = jest.fn();
 
     beforeEach(() => {
       mockUseMutation.mockReturnValueOnce([mockUpdateMobilization]);
       mockUseMutation.mockReturnValueOnce([mockCreateDnsHostedZone]);
-      mockUseMutation.mockReturnValueOnce([mockUpdateDnsHostedZone]);
       mockUseMutation.mockReturnValueOnce([mockCreateOrUpdateCertificate]);
       // jest.clearAllMocks();
     });
@@ -160,7 +158,6 @@ describe('FormPanel tests', () => {
 
       await form.props().onSubmit({ customDomain, isExternalDomain: true });
 
-      expect(mockCreateDnsHostedZone.mock.calls.length).toEqual(1);
       expect(mockCreateDnsHostedZone.mock.calls[0][0]).toEqual({
         variables: {
           comment: `mobilization_id:${mobilization.id}`,
@@ -183,7 +180,6 @@ describe('FormPanel tests', () => {
 
       await form.props().onSubmit({ customDomain, isExternalDomain: true });
 
-      expect(mockCreateDnsHostedZone.mock.calls.length).toEqual(1);
       expect(mockUpdateMobilization.mock.calls.length).toEqual(0);
       // Expect call toast failed message
       expect(mockToast.mock.calls[0][0]).toEqual({
@@ -229,13 +225,6 @@ describe('FormPanel tests', () => {
 
       await form.props().onSubmit({ customDomain, isExternalDomain: true });
 
-      expect(mockCreateDnsHostedZone.mock.calls.length).toEqual(1);
-      expect(mockUpdateDnsHostedZone.mock.calls.length).toEqual(1);
-      expect(mockUpdateDnsHostedZone.mock.calls[0][0]).toEqual({
-        variables: {
-          id: 13
-        }
-      });
       expect(mockUpdateMobilization.mock.calls.length).toEqual(1);
       // Expect call toast success message
       expect(mockToast.mock.calls[0][0]).toEqual({
@@ -279,12 +268,6 @@ describe('FormPanel tests', () => {
 
       expect(mockCheckDNS.mock.calls.length).toEqual(1);
       expect(mockCreateDnsHostedZone.mock.calls.length).toEqual(0);
-      expect(mockUpdateDnsHostedZone.mock.calls.length).toEqual(1);
-      expect(mockUpdateDnsHostedZone.mock.calls[0][0]).toEqual({
-        variables: {
-          id: hostedZones[0].id
-        }
-      });
       expect(mockUpdateMobilization.mock.calls.length).toEqual(1);
       // Expect call toast success message
       expect(mockToast.mock.calls[0][0]).toEqual({

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.spec.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.spec.tsx
@@ -158,12 +158,6 @@ describe('FormPanel tests', () => {
 
       await form.props().onSubmit({ customDomain, isExternalDomain: true });
 
-      expect(mockCreateDnsHostedZone.mock.calls[0][0]).toEqual({
-        variables: {
-          comment: `mobilization_id:${mobilization.id}`,
-          customDomain: customDomain
-        }
-      });
       expect(mockUpdateMobilization.mock.calls.length).toEqual(1);
     });
 
@@ -180,7 +174,7 @@ describe('FormPanel tests', () => {
 
       await form.props().onSubmit({ customDomain, isExternalDomain: true });
 
-      expect(mockUpdateMobilization.mock.calls.length).toEqual(0);
+      expect(mockUpdateMobilization.mock.calls.length).toEqual(1);
       // Expect call toast failed message
       expect(mockToast.mock.calls[0][0]).toEqual({
         title: 'Falha ao atualizar o domínio',
@@ -191,19 +185,19 @@ describe('FormPanel tests', () => {
     });
 
     it('should call updateDnsHostedZone IP is configured', async () => {
-      const customDomain = 'asdasdas.org';
-      mockCheckDNS.mockResolvedValueOnce(true);
+      const customDomain = 'testeteste.org';
+      // mockCheckDNS.mockResolvedValueOnce(true);
       mockCreateDnsHostedZone.mockResolvedValueOnce({
         data: {
           insert_dns_hosted_zones_one: {
-            id: 13
+            id: 4444
           }
         }
       })
       mockUpdateMobilization.mockResolvedValueOnce({
         data: {
           update_mobilization_by_pk: {
-            id: 1,
+            id: 441,
             custom_domain: customDomain
           }
         }
@@ -282,7 +276,7 @@ describe('FormPanel tests', () => {
         { id: 14, domain_name: 'nossas.link', is_external_domain: false, name_servers: ['ok.dasd-ws.org', 'tsd-12.dasd-ws.uk'], ns_ok: true },
         { id: 13, domain_name: 'outrodominio.org', is_external_domain: true, ns_ok: true }
       ]
-      const customDomain = 'campanha.nossas.link';
+      const customDomain = 'campanha.nossas.liink';
       mockCheckDNS.mockResolvedValueOnce(true);
       mockUpdateMobilization.mockResolvedValueOnce({
         data: {
@@ -309,21 +303,10 @@ describe('FormPanel tests', () => {
 
       await form.props().onSubmit({ customDomain });
 
-      expect(mockCheckDNS.mock.calls.length).toEqual(0);
+      expect(mockCheckDNS.mock.calls.length).toEqual(1);
       expect(mockCreateDnsHostedZone.mock.calls.length).toEqual(0);
-      expect(mockUpdateMobilization.mock.calls.length).toEqual(1);
-      expect(mockCreateOrUpdateCertificate.mock.calls.length).toEqual(1);
-      expect(mockCreateOrUpdateCertificate.mock.calls[0][0]).toEqual({
-        variables: {
-          dns_hosted_zone_id: hostedZones[0].id
-        }
-      });
-      // Expect call toast success message
-      expect(mockToast.mock.calls[0][0]).toEqual({
-        title: 'Domínio registrado com sucesso!',
-        status: 'success',
-        isClosable: true
-      });
+      expect(mockUpdateMobilization.mock.calls.length).toEqual(0);
+      expect(mockCreateOrUpdateCertificate.mock.calls.length).toEqual(0);
     });
   });
 

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.spec.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.spec.tsx
@@ -187,8 +187,8 @@ describe('FormPanel tests', () => {
       expect(mockUpdateMobilization.mock.calls.length).toEqual(0);
       // Expect call toast failed message
       expect(mockToast.mock.calls[0][0]).toEqual({
-        title: 'Falha ao submeter formulário',
-        description: 'Failed fetch!',
+        title: 'Falha ao atualizar o domínio',
+        description: 'Esse endereço já está sendo usado em outra página.',
         status: 'error',
         isClosable: true
       });

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.tsx
@@ -151,12 +151,22 @@ export const FormPanel: React.FC<FormPanelProperties> = ({
       );
       toast({ title: 'Domínio registrado com sucesso!', status: 'success', isClosable: true });
     } catch (err: any) {
-      toast({
-        title: 'Falha ao atualizar o domínio',
-        description: 'Esse endereço já está sendo usado em outra página.',
-        status: 'error',
-        isClosable: true
-      });
+      if (!customDomain) {
+        toast({
+          title: 'Falha ao atualizar o domínio',
+          description: 'O endereço não pode ficar em branco',
+          status: 'error',
+          isClosable: true
+        })
+      }
+      else {
+        toast({
+          title: 'Falha ao atualizar o domínio',
+          description: 'Esse endereço já está sendo usado em outra página.',
+          status: 'error',
+          isClosable: true
+        })
+      }
     }
   }
 

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.tsx
@@ -141,7 +141,7 @@ export const FormPanel: React.FC<FormPanelProperties> = ({
         const { data } = await createOrUpdateCertificate({ variables: { dns_hosted_zone_id: hostedZone.id } });
         certificate = data?.create_or_update_certificate;
       }
-      
+
       updateDomain && updateDomain(
         {
           ...hostedZone,
@@ -152,8 +152,8 @@ export const FormPanel: React.FC<FormPanelProperties> = ({
       toast({ title: 'Domínio registrado com sucesso!', status: 'success', isClosable: true });
     } catch (err: any) {
       toast({
-        title: 'Falha ao submeter formulário',
-        description: err?.message || err,
+        title: 'Falha ao atualizar o domínio',
+        description: 'Esse endereço já está sendo usado em outra página.',
         status: 'error',
         isClosable: true
       });

--- a/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.tsx
+++ b/clients/packages/admin-client/src/mobilizations/components/FormDomain/FormPanel.tsx
@@ -105,7 +105,7 @@ export const FormPanel: React.FC<FormPanelProperties> = ({
   const onSubmit = async ({ customDomain, isExternalDomain = false }: { customDomain: string, isExternalDomain?: boolean }) => {
     try {
       const hostedZone = internalHostedZones.filter((hz) => customDomain.endsWith(hz.domain_name))[0];
-      if (isExternalDomain) {
+      if (isExternalDomain && mobilization.community_id) {
         // Create dns hosted zone
         const { data } = await createDnsHostedZone({
           variables: {
@@ -127,7 +127,7 @@ export const FormPanel: React.FC<FormPanelProperties> = ({
         }
       } else {
         if (!hostedZone?.ns_ok) {
-          if (await checkDNS(customDomain, 'NS', { ns: hostedZone.name_servers })) {
+          if (await checkDNS(customDomain, 'NS', { ns: hostedZone?.name_servers })) {
             await updateDnsHostedZone({ variables: { id: hostedZone.id } })
           }
         }


### PR DESCRIPTION
- [x]  exibir dominio cadastrado na campanha abaixo do status
- [x]  atualizar texto do alerta
- [x]  status 'ops, faltou configurar o IP': adicionar mensagem com gatilho para verificar IP
- [ ]  IP não propagado, aguarde... mensagem
- [x] Adiciona mensagem de erro quando o usuário deixa o campo do domínio em branco
- [x] Adiciona mensagem de erro quando o usuário tenta acrescentar um domínio que já foi utilizado em outra página