### PR TITLE
Atualizar conversão de imagem para jpeg por padrão

### DIFF
--- a/clients/libs/slate-editor-image-plugin/src/ImageLinkNode.js
+++ b/clients/libs/slate-editor-image-plugin/src/ImageLinkNode.js
@@ -1,22 +1,22 @@
 /* eslint-disable react/prop-types */
-import React, { Component } from 'react'
-import classnames from 'classnames'
+import React, { Component } from "react";
+import classnames from "classnames";
 
-import ImageDataModal from './ImageDataModal'
-import ImageEditLayer from './ImageEditLayer'
+import ImageDataModal from "./ImageDataModal";
+import ImageEditLayer from "./ImageEditLayer";
 
 class ImageLinkNode extends Component {
   constructor(props) {
-    super(props)
-    this.state = { isModalActive: false }
+    super(props);
+    this.state = { isModalActive: false };
   }
 
   modal(isModalActive) {
-    this.setState({ isModalActive })
+    this.setState({ isModalActive });
   }
 
   render() {
-    const { isModalActive } = this.state
+    const { isModalActive } = this.state;
     const {
       node,
       attributes,
@@ -24,9 +24,9 @@ class ImageLinkNode extends Component {
       isSelected,
       editor: {
         onChange,
-        props: { value }
-      }
-    } = this.props
+        props: { value },
+      },
+    } = this.props;
 
     return (
       <span>
@@ -39,7 +39,11 @@ class ImageLinkNode extends Component {
           />
         )}
 
-        <div className={classnames('image-node--container', { readonly: readOnly })}>
+        <div
+          className={classnames("image-node--container", {
+            readonly: readOnly,
+          })}
+        >
           {this.props.children}
           {isSelected && (
             <ImageEditLayer
@@ -48,39 +52,45 @@ class ImageLinkNode extends Component {
             />
           )}
           {!readOnly && !isSelected && (
-            <ImageEditLayer
-              text="Selecione a imagem para editar"
-            />
+            <ImageEditLayer text="Selecione a imagem para editar" />
           )}
           <a
-            href={node.data.get('href')}
-            target={node.data.get('openExternal') ? '_blank' : '_self'}
+            href={node.data.get("href")}
+            target={node.data.get("openExternal") ? "_blank" : "_self"}
           >
-            {(("REACT_APP_DOMAIN_IMAGINARY" in process.env) && (!node.data.get('src').match(/gif$/i))) ?
+            {"REACT_APP_DOMAIN_IMAGINARY" in process.env &&
+            !node.data.get("src").match(/gif$/i) ? (
               <img
                 {...attributes}
                 role="presentation"
                 loading="lazy"
-                className={`image-node ${!readOnly && isSelected && 'selected'}`}
-                src={`${process.env.REACT_APP_DOMAIN_IMAGINARY}/convert?url=${node.data.get('src')}&type=auto`}
-                title={node.data.get('title')}
-                alt={node.data.get('title')}
-              /> :
-              <img
-                {...attributes}
-                role="presentation"
-                loading="lazy"
-                className={`image-node ${!readOnly && isSelected && 'selected'}`}
-                src={node.data.get('src')}
-                title={node.data.get('title')}
-                alt={node.data.get('title')}
+                className={`image-node ${
+                  !readOnly && isSelected && "selected"
+                }`}
+                src={`${
+                  process.env.REACT_APP_DOMAIN_IMAGINARY
+                }/convert?url=${node.data.get("src")}&type=jpeg`}
+                title={node.data.get("title")}
+                alt={node.data.get("title")}
               />
-            }
+            ) : (
+              <img
+                {...attributes}
+                role="presentation"
+                loading="lazy"
+                className={`image-node ${
+                  !readOnly && isSelected && "selected"
+                }`}
+                src={node.data.get("src")}
+                title={node.data.get("title")}
+                alt={node.data.get("title")}
+              />
+            )}
           </a>
         </div>
       </span>
-    )
+    );
   }
 }
 
-export default ImageLinkNode
+export default ImageLinkNode;

--- a/clients/libs/slate-editor-image-plugin/src/ImageNode.js
+++ b/clients/libs/slate-editor-image-plugin/src/ImageNode.js
@@ -1,32 +1,37 @@
 /* eslint-disable no-undef */
 /* eslint-disable react/prop-types */
-import React, { Component } from 'react'
-import classnames from 'classnames'
+import React, { Component } from "react";
+import classnames from "classnames";
 
-import ImageDataModal from './ImageDataModal'
-import ImageEditLayer from './ImageEditLayer'
+import ImageDataModal from "./ImageDataModal";
+import ImageEditLayer from "./ImageEditLayer";
 
 // FIXME: Needs to handle assets files to work with SSR
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-if (require('exenv').canUseDOM) require('./ImageNode.module.css')
+if (require("exenv").canUseDOM) require("./ImageNode.module.css");
 
 class ImageNode extends Component {
   constructor(props) {
-    super(props)
-    this.state = { isModalActive: false }
+    super(props);
+    this.state = { isModalActive: false };
   }
 
   modal(isModalActive) {
     if (isModalActive) {
-      const { editor: { onChange, props: { value } } } = this.props
-      onChange(value.change().select())
+      const {
+        editor: {
+          onChange,
+          props: { value },
+        },
+      } = this.props;
+      onChange(value.change().select());
     }
 
-    this.setState({ isModalActive })
+    this.setState({ isModalActive });
   }
 
   render() {
-    const { isModalActive } = this.state
+    const { isModalActive } = this.state;
     const {
       node,
       attributes,
@@ -34,9 +39,9 @@ class ImageNode extends Component {
       isSelected,
       editor: {
         onChange,
-        props: { value }
-      }
-    } = this.props
+        props: { value },
+      },
+    } = this.props;
 
     return (
       <span>
@@ -49,7 +54,11 @@ class ImageNode extends Component {
           />
         )}
 
-        <div className={classnames('image-node--container', { readonly: readOnly })}>
+        <div
+          className={classnames("image-node--container", {
+            readonly: readOnly,
+          })}
+        >
           {this.props.children}
           {isSelected && (
             <ImageEditLayer
@@ -58,34 +67,36 @@ class ImageNode extends Component {
             />
           )}
           {!readOnly && !isSelected && (
-            <ImageEditLayer
-              text="Selecione a imagem para editar"
+            <ImageEditLayer text="Selecione a imagem para editar" />
+          )}
+          {"REACT_APP_DOMAIN_IMAGINARY" in process.env &&
+          !node.data.get("src").match(/gif$/i) ? (
+            <img
+              {...attributes}
+              role="presentation"
+              loading="lazy"
+              className={`image-node ${!readOnly && isSelected && "selected"}`}
+              src={`${
+                process.env.REACT_APP_DOMAIN_IMAGINARY
+              }/convert?url=${node.data.get("src")}&type=jpeg`}
+              title={node.data.get("title")}
+              alt={node.data.get("title")}
+            />
+          ) : (
+            <img
+              {...attributes}
+              role="presentation"
+              loading="lazy"
+              className={`image-node ${!readOnly && isSelected && "selected"}`}
+              src={node.data.get("src")}
+              title={node.data.get("title")}
+              alt={node.data.get("title")}
             />
           )}
-          {(("REACT_APP_DOMAIN_IMAGINARY" in process.env) && (!node.data.get('src').match(/gif$/i))) ?
-            <img
-              {...attributes}
-              role="presentation"
-              loading="lazy"
-              className={`image-node ${!readOnly && isSelected && 'selected'}`}
-              src={`${process.env.REACT_APP_DOMAIN_IMAGINARY}/convert?url=${node.data.get('src')}&type=auto`}
-              title={node.data.get('title')}
-              alt={node.data.get('title')}
-            /> :
-            <img
-              {...attributes}
-              role="presentation"
-              loading="lazy"
-              className={`image-node ${!readOnly && isSelected && 'selected'}`}
-              src={node.data.get('src')}
-              title={node.data.get('title')}
-              alt={node.data.get('title')}
-            />
-          }
         </div>
       </span>
-    )
+    );
   }
 }
 
-export default ImageNode
+export default ImageNode;

--- a/clients/packages/webpage-client/src/bonde-webpage/components/Section.tsx
+++ b/clients/packages/webpage-client/src/bonde-webpage/components/Section.tsx
@@ -22,7 +22,7 @@ const getBackgroundStyle = (block: any) => {
       // gif files should not be optimized
       if (!block.bg_image.match(/gif$/i)) {
         return {
-          background: `url('${process.env.REACT_APP_DOMAIN_IMAGINARY}/convert?url=${block.bg_image}&type=auto') no-repeat`,
+          background: `url('${process.env.REACT_APP_DOMAIN_IMAGINARY}/convert?url=${block.bg_image}&type=jpeg') no-repeat`,
           backgroundSize: 'cover',
         };
       }


### PR DESCRIPTION
## Contexto
Alguns navegadores estão recebendo a imagem de placeholder ao invés da oficial, estou forçando para conversão de imagem ser sempre o jpeg.


## Checklist
- [x] Atualizar Link c/ Imagem no Editor de mobilização
- [x] Atualizar Imagem no Editor de mobilização
- [x] Atualizar imagem de fundo do bloco no Editor de mobilização

## Notas de deploy
* 

## Como testar?
* Abrir o editor de conteúdo no editor de mobilização e tentar subir uma image e depois abrir a mobilização e visualizar a imagem. Garantir que a imagem carregada está apontando para o IMAGINARY e que ela seja jpeg
* Para além de atualizar o formato padrão de export, a ideia é que caso o cache esteja comprometendo o carregamento da imagem, é possível que ao trocar um parametro da url, o cache seja invalidado e tenha que sempre baixar.
