### PR TITLE
plip counter/plip performance

### DIFF
--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/ExpectedSignaturesFilter.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/ExpectedSignaturesFilter.tsx
@@ -19,8 +19,8 @@ const ExpectedSignaturesFilter: React.FC<Props> = ({ onChange }) => {
           { value: 20, label: '20' },
           { value: 50, label: '50' },
           { value: 100, label: '100' },
-          { value: 100, label: '500' },
-          { value: 100, label: '1000' },
+          { value: 500, label: '500' },
+          { value: 1000, label: '1000' },
         ]}
         onChange={(item: any) => {
           onChange(item.value);

--- a/clients/packages/webpage-client/src/bonde-webpage/plugins/Plip/form/PlipForm.tsx
+++ b/clients/packages/webpage-client/src/bonde-webpage/plugins/Plip/form/PlipForm.tsx
@@ -83,7 +83,7 @@ const PlipForm: React.FC<Props> = ({ asyncFillWidget, widget }) => {
                 <div>
                   <label>Estado* </label>
                   <select {...input}>
-                    <option>Selecione o Estado</option>
+                    <option value="" disabled selected>Selecione o Estado</option>
                     <option value="EX">Estrangeiro</option>
                     <option value="AC">Acre</option>
                     <option value="AL">Alagoas</option>
@@ -134,7 +134,7 @@ const PlipForm: React.FC<Props> = ({ asyncFillWidget, widget }) => {
                 <div>
                   <label>Quantidade de Assinaturas* </label>
                   <select {...input}>
-                    <option>selecione a quantidade de assinaturas</option>
+                    <option value="" disabled selected>selecione a quantidade de assinaturas</option>
                     <option value="10">10</option>
                     <option value="20">20</option>
                     <option value="50">50</option>
@@ -151,7 +151,7 @@ const PlipForm: React.FC<Props> = ({ asyncFillWidget, widget }) => {
                 <div>
                   <label>Com qual raça/cor você se identifica?</label>
                   <select {...input}>
-                    <option>selecione entre as opções</option>
+                    <option value="" disabled selected>selecione entre as opções</option>
                     <option value="amarela">Amarela</option>
                     <option value="branca">Branca</option>
                     <option value="indigena">Indígena</option>
@@ -166,7 +166,7 @@ const PlipForm: React.FC<Props> = ({ asyncFillWidget, widget }) => {
                 <div>
                   <label>Você é...</label>
                   <select {...input}>
-                    <option>selecione entre as opções</option>
+                    <option value="" disabled selected>selecione entre as opções</option>
                     <option value="mulher-cisgenero">Mulher cisgênero</option>
                     <option value="mulher-transgenero">Mulher transgênero</option>
                     <option value="homem-cisgenero">Homem cisgênero</option>

--- a/clients/packages/webpage-client/src/pages/api/plip-counter/index.ts
+++ b/clients/packages/webpage-client/src/pages/api/plip-counter/index.ts
@@ -26,6 +26,7 @@ export default async function fetchSignatures(req: NextApiRequest, res: NextApiR
   if (method === "GET") {
     const signaturesTotal = await client.query({
       query,
+      fetchPolicy: "no-cache"
     })
     return res.status(200).json({
       data: signaturesTotal


### PR DESCRIPTION
- [x] Remover cache do contador da Plip para atualizar número automaticamente

- [x] Desabilitar opção de placeholder no formulário da Plip para evitar valores nulos
 
- [x] Corrigir filtro para retornar valores de 500 e 1000 assinaturas na tela de performance
