### PR TITLE
chore: separate query that counts activists

### DIFF
--- a/clients/packages/webpage-client/src/pages/api/plip-activists-counter/index.ts
+++ b/clients/packages/webpage-client/src/pages/api/plip-activists-counter/index.ts
@@ -4,20 +4,13 @@ import { gql } from '@apollo/client';
 
 const query = gql`
 query {
-  plips_aggregate(where: {widget_id: {_eq: 70801}, status: {_in: ["PENDENTE", "INSCRITO"]}}) {
+  plips_aggregate(where: {widget_id: {_eq: 70801}}, distinct_on: unique_identifier) {
     aggregate {
       sum {
-        expected_signatures
+        id
       }
     }
   }
-  plip_signatures_aggregate(where: {widget_id: {_eq: 70801}}) {
-     aggregate {
-      sum {
-         confirmed_signatures
-      }
-     }
-   }
 }
 `
 


### PR DESCRIPTION
Após o seguinte erro nos logs do webpage:

```
 graphQLErrors: [
    {
      extensions: [Object],
      message: 'inconsistent arguments between multiple selections of field "plips_aggregate"'
    }
  ]
```

foi preciso criar outra rota para a query que conta o número de pessoas atuando na plip

