### PR TITLE
feat(canary): add state field to confirm plip signatures

### DIFF
--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/QRForm.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/QRForm.tsx
@@ -128,7 +128,8 @@ export const QRForm: React.FC<Properties> = ({ widget }) => {
       onSubmit={handleSubmit}
       initialValues={{
         unique_identifier: code,
-        confirmed_signatures: plipForm?.expected_signatures
+        confirmed_signatures: plipForm?.expected_signatures,
+        state: plipForm?.state
       }}
     >
       <Wizard.Page>

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/QRForm.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/QRForm.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useContext } from "react";
 import { Link, useParams } from "react-router-dom";
-import { InputField } from "bonde-components";
+import { InputField, SelectField } from "bonde-components";
 import { Button, Flex, Heading, Text, Stack } from "bonde-components/chakra";
 import { useMutation, useQuery, gql, Context as SessionContext } from "bonde-core-tools";
 
 import type { Widget } from "../../FetchWidgets";
+import { STATES } from "./datatable/StatesFilter";
 import Wizard from "./components/Wizard";
 import useQueryParams from "./useQueryParams";
 
@@ -39,6 +40,7 @@ const INSERT_PLIP_SIGNATURE_FORM = gql`
       id
       created_at
       confirmed_signatures
+      state
     }
   }
 `;
@@ -58,10 +60,11 @@ export const QRForm: React.FC<Properties> = ({ widget }) => {
   if (loading) return <p>Carregando formulário...</p>;
   if (error) return <p>Failed!</p>
 
-  const handleSubmit = ({ unique_identifier, confirmed_signatures }: any) => {
+  const handleSubmit = ({ unique_identifier, confirmed_signatures, state }: any) => {
     const input: any = {
       unique_identifier,
       confirmed_signatures,
+      state,
       widget_id: widget.id
     }
 
@@ -152,6 +155,13 @@ export const QRForm: React.FC<Properties> = ({ widget }) => {
             name="confirmed_signatures"
             label="Total de assinaturas"
           />
+          <SelectField
+            name="state"
+            label="Estado"
+          >
+            {STATES.map(({ value, label }) =>
+              <option key={value} value={value}>{label}</option>)}
+          </SelectField>
         </Stack>
       </Wizard.Page>
     </Wizard>

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/StatesFilter.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/StatesFilter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormControl } from 'bonde-components/chakra';
 import Select from "../components/ChakraReactSelect";
 
-const STATES = [
+export const STATES = [
   { value: "AC", label: "AC" },
   { value: "AL", label: "AL" },
   { value: "AM", label: "AM" },


### PR DESCRIPTION
## Contexto
Com a coleta de assinaturas para PLIP a nível nacional, surgiu a necessidade de especificar dentro de um mesmo formulário (Código Unico) diferentes estados, mudando a relação do estado que antes era adicionado apenas na ficha.

Esse PR tem objetivo de entregar a primeira parte dessa mudança, que abrange apenas a inclusão do campo no modelo de dados que representa a assinatura, em um segundo momento iremos revisar os dados analiticos (dashboard da PLIP) para considerar essa nova informação de estado.

## Mudanças
- Adiciona campo Estado no formulário que confirma assinaturas
- https://github.com/nossas/bonde-apis/pull/63