### PR TITLE
feat: add csv export of delivered signatures

### DIFF
--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/SignaturesExportCSV.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/SignaturesExportCSV.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+import { gql, useLazyQuery } from 'bonde-core-tools';
+import { createVariables, useQueryFiltersFields } from './SignaturesQueryProvider';
+import { Button } from 'bonde-components/chakra';
+
+export const QUERY = gql`
+    query ($where: plip_signatures_bool_exp) {
+    plip_signatures(
+      where: $where
+      order_by: {created_at: desc}
+    ) {
+      confirmed_signatures
+      created_at
+      state
+      plips {
+        name: form_data(path: "name")
+        email: form_data(path: "email")
+        whatsapp: form_data(path: "whatsapp")
+        expected_signatures
+        state
+        status
+      }
+    }
+  }
+`;
+
+interface Props {
+  widgetId: number;
+  fileName: string;
+}
+
+// json to CSV
+const jsonToCSV = (data): string => {
+  const rows: any = [];
+
+  rows.push('', 'Nome', 'E-mail', 'Estado', 'Assinaturas Entregues', 'Data Registro', 'Whatsapp', 'Status', '\n')
+  data.forEach((activist) => {
+    const deliveryDate = new Date(activist.created_at)
+    const formattedDate = (deliveryDate.getDate()) + "/" + (deliveryDate.getMonth() + 1) + "/" + deliveryDate.getFullYear();
+    rows.push(activist.plips[0].name, activist.plips[0].email, activist.state, activist.confirmed_signatures, formattedDate, activist.plips[0].whatsapp, activist.plips[0].status, '\n')
+  })
+  return "data:text/csv;charset=utf-8," +
+    rows;
+}
+
+const SignaturesExportCSV: React.FC<Props> = ({ widgetId, fileName }) => {
+  const { states, signatures } = useQueryFiltersFields();
+  const [fetchConfirmedSignatures, { called, loading, data }] = useLazyQuery(QUERY, {
+    variables: createVariables({ widgetId, states, signatures })
+  });
+
+  useEffect(() => {
+    if (called && !loading && data) {
+      const encodedUri = encodeURI(jsonToCSV(data.plip_signatures));
+      const link = document.createElement("a");
+      link.setAttribute("href", encodedUri);
+      link.setAttribute("download", `${fileName}.csv`);
+      document.body.appendChild(link); // Required for FF
+
+      link.click();
+    }
+  }, [called, loading, data, fileName]);
+
+  return (
+    <Button variant="outline" colorScheme="gray" onClick={fetchConfirmedSignatures} disabled={called && loading}>
+      {called && loading ? 'Exportando CSV...' : 'Exportar'}
+    </Button>
+  );
+}
+
+export default SignaturesExportCSV;

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/SignaturesTableView.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Plips/datatable/SignaturesTableView.tsx
@@ -13,7 +13,7 @@ import {
   Heading
 } from 'bonde-components/chakra';
 import EmailFilter from './EmailFilter';
-import ExportCSV from './ExportCSV';
+import SignaturesExportCSV from './SignaturesExportCSV';
 import Pagination from './Pagination';
 import StateFilter from './StatesFilter';
 import SignaturesFiltersProvider, {
@@ -55,9 +55,7 @@ const Row: React.FC<{ plipSignature: PlipSignature }> = ({ plipSignature }) => {
 
 const SignaturesTable: React.FC<any> = ({ widgetId }) => {
   const { data, loading } = useQueryFiltersData();
-  // const { data2, confirmedTotal } = useQueryBFiltersData();
   const { pageIndex, onChangePage, onPreviousPage, onNextPage, pages, total } = useQueryFiltersPage();
-  // const { pages, onNextPage } = useQueryBFiltersPage();
   const { onChangeLimit } = useQueryFiltersLimit();
   const { onChangeStates, onChangeEmail } = useQueryFiltersFields();
 
@@ -77,7 +75,7 @@ const SignaturesTable: React.FC<any> = ({ widgetId }) => {
           <EmailFilter onChange={onChangeEmail} />
           <StateFilter onChange={onChangeStates} />
         </Stack>
-        <ExportCSV widgetId={widgetId} fileName="relatorio-plips" />
+        <SignaturesExportCSV widgetId={widgetId} fileName="relatorio-plips" />
       </Flex>
       <Table variant="simple" bg="white" maxH="500px">
         <TableCaption>


### PR DESCRIPTION
- [x] Adiciona possibilidade de exportar dados da tabela de assinaturas confirmadas, localizada na tela de performance da Plip

Testes podem ser feitos em staging, na comunidade e widget da Plip

Screenshots:
![image](https://user-images.githubusercontent.com/68885458/191503413-64262892-25f5-4ec9-8e96-7c6122efd773.png)
![image](https://user-images.githubusercontent.com/68885458/191503496-beefef9e-d6d5-4fc3-b305-593a64bd6db7.png)
