### PR TITLE
Adiciona capacidade de assuntos randomicos a pressão por e-mail

### DIFF
--- a/clients/packages/webpage-client/src/activists/pressure.ts
+++ b/clients/packages/webpage-client/src/activists/pressure.ts
@@ -62,6 +62,13 @@ const pressure = async ({ payload, widget }: Args): Promise<any> => {
       pressureInput.email_body = mail.body;
     }
 
+    // Teste de pressões com assuntos randomicos
+    if (widget.id == 75246) {
+    // if (widget.id == 23194) {
+      pressureInput.email_subject = mail.subject;
+      pressureInput.email_body = mail.body;
+    }
+
     const variables = {
       activist: input,
       widget_id: widget.id,

--- a/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
+++ b/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
@@ -67,7 +67,7 @@ const PressureForm = ({
       show_state: showState,
       main_color: buttonColor,
       button_text: buttonText,
-      pressure_subject: subject = '',
+      // pressure_subject: subject = '',
       pressure_body: body = '',
       pressure_type,
       select_label,
@@ -78,6 +78,46 @@ const PressureForm = ({
     label: groupTarget.label,
     value: groupTarget.identify,
   }));
+
+  // Teste de pressões com assuntos randomicos
+  let {
+    settings: {
+      pressure_subject: subject = '',
+    }
+  } = widget;
+
+  if (widget.id == 75246) {
+  // if (widget.id == 23194) {
+    const random_subjects_list = [
+      "Ministro Lewandowski, o Brasil conta com você",
+      "Queremos o fim do Orçamento Secreto",
+      "Ministro, conto com você pelo fim do Orçamento Secreto",
+      "Queremos transparência nos gastos públicos",
+      "Contamos com o seu voto pelo fim do Orçamento Secreto",
+      "Caro Ministro, você pode dar um presente para os brasileiros",
+      "O Orçamento Secreto não pode continuar!",
+      "Fim do Orçamento Secreto Já, Ministro!",
+      "Excelentíssimo Ministro, a corrupção não pode prevalecer!",
+      "Ministro Lewandowski, o maior escândalo de corrupção tá em suas mãos",
+      "O seu voto pode salvar a nossa democracia, Ministro",
+      "Mais transparência para o país",
+      "Transparência no orçamento público",
+      "Julgamento do Orçamento Secreto",
+      "Ministro, o Brasil precisa do seu voto",
+      "Democracia com transparência",
+      "Ministro Lewandowski, vote pela transparência!",
+      "Ministro, eu quero o fim do orçamento secreto",
+      "A transparência nos gastos está nas suas mãos, Ministro",
+      "Ministro, contamos com o senhor",
+      "Ministro, o seu voto é nossa última chance"
+    ];
+
+    const min = Math.ceil(0);
+    const max = Math.floor(random_subjects_list.length - 1);
+    const position = Math.floor(Math.random() * (max - min + 1)) + min;
+
+    subject = random_subjects_list[position] as string
+  }
 
   return (
     <Form


### PR DESCRIPTION
Esse PR adiciona assuntos randomizados apenas para widget 75246, com intuito de testar esse modelo de configuração da ação de pressão por e-mail, no caso de sucesso, devemos melhorar essa implementação para trabalhar com assuntos randomicos salvos na configuração da widget. 