### PR TITLE
fix: returns user email with lowercase letters

### DIFF
--- a/clients/packages/webpage-client/src/bonde-webpage/plugins/Form/index.tsx
+++ b/clients/packages/webpage-client/src/bonde-webpage/plugins/Form/index.tsx
@@ -135,6 +135,13 @@ const FormPlugin = (props: Props) => {
 
     const fieldsWithValue = addValueToFields(widget.settings.fields, values);
 
+    // returns user email with lowercase letters
+    fieldsWithValue.map((field: any) => {
+      if (field.kind === 'email') {
+        return field.value = field.value?.toLowerCase();
+      }
+    });
+
     const errors = validate(fieldsWithValue, { t });
 
     if (errors.length > 0) {


### PR DESCRIPTION
- [x] Problema levantado durante análise de problemas com cadastro de voluntárias do mapa do acolhimento. Esse commit faz um map que retorna sempre um e-mail com letras minúsculas, mesmo que a usuária digite letras maiúsculas
