### PR TITLE
[Feature] Pressão com assuntos alternados

### DIFF
--- a/clients/packages/canary-client/public/locales/en/widgetActions.json
+++ b/clients/packages/canary-client/public/locales/en/widgetActions.json
@@ -92,14 +92,16 @@
         "email_body": "Corpo do e-mail para os alvos",
         "group_label": "Nome do grupo de alvos",
         "select_label": "Nome do campo de seleção",
-        "disable_edit_field": "Desabilitar edição de assunto e corpo do email?"
+        "disable_edit_field": "Desabilitar edição de assunto e corpo do email?",
+        "is_subject_list": "Habilitar assuntos alternados?"
       },
       "placeholder": {
         "targets": "Nome do alvo 1 <nome1@alvo.org>;Nome do alvo 2 <nome2@alvo.org>",
         "email_subject": "Escreva um assunto",
         "email_body": "Escreva aqui o email...",
         "group_label": "Ex. Rio de Janeiro",
-        "select_label": "Ex: Selecione seu estado"
+        "select_label": "Ex: Selecione seu estado",
+        "is_subject_list": "Escreva um assunto e pressione [ENTER]"
       },
       "button": {
         "cancel": "Cancelar",

--- a/clients/packages/canary-client/public/locales/es/widgetActions.json
+++ b/clients/packages/canary-client/public/locales/es/widgetActions.json
@@ -92,14 +92,16 @@
         "email_body": "Corpo do e-mail para os alvos",
         "group_label": "Nome do grupo de alvos",
         "select_label": "Nome do campo de seleção",
-        "disable_edit_field": "Desabilitar edição de assunto e corpo do email?"
+        "disable_edit_field": "Desabilitar edição de assunto e corpo do email?",
+        "is_subject_list": "Habilitar assuntos alternados?"
       },
       "placeholder": {
         "targets": "Nome do alvo 1 <nome1@alvo.org>;Nome do alvo 2 <nome2@alvo.org>",
         "email_subject": "Escreva um assunto",
         "email_body": "Escreva aqui o email...",
         "group_label": "Ex. Rio de Janeiro",
-        "select_label": "Ex: Selecione seu estado"
+        "select_label": "Ex: Selecione seu estado",
+        "is_subject_list": "Escreva um assunto e pressione [ENTER]"
       },
       "button": {
         "cancel": "Cancelar",

--- a/clients/packages/canary-client/public/locales/pt-BR/widgetActions.json
+++ b/clients/packages/canary-client/public/locales/pt-BR/widgetActions.json
@@ -57,14 +57,16 @@
         "email_body": "Corpo do e-mail para os alvos",
         "group_label": "Nome do grupo de alvos",
         "select_label": "Nome do campo de seleção",
-        "disable_edit_field": "Desabilitar edição de assunto e corpo do email?"
+        "disable_edit_field": "Desabilitar edição de assunto e corpo do email?",
+        "is_subject_list": "Habilitar assuntos alternados?"
       },
       "placeholder": {
         "targets": "Nome do alvo 1 <nome1@alvo.org>;Nome do alvo 2 <nome2@alvo.org>",
         "email_subject": "Escreva um assunto",
         "email_body": "Escreva aqui o email...",
         "group_label": "Ex. Rio de Janeiro",
-        "select_label": "Ex: Selecione seu estado"
+        "select_label": "Ex: Selecione seu estado",
+        "is_subject_list": "Escreva um assunto e pressione [ENTER]"
       },
       "button": {
         "cancel": "Cancelar",

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Pressure/ConfigurePressureTargets/SubjectBodyFields.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Pressure/ConfigurePressureTargets/SubjectBodyFields.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { InputField, TextareaField } from 'bonde-components';
+import { Stack } from 'bonde-components/chakra';
 import { useTranslation } from 'react-i18next';
+
 import TagInputField from "./TagInputField";
+import SpyField from '../../../../../components/SpyField';
 
 type SubjectBodyFieldsProps = {
   prefix?: string
@@ -34,24 +37,35 @@ const SubjectBodyFields: React.FC<SubjectBodyFieldsProps> = ({ prefix, emailSubj
   const emailBody = emailBodyName ? emailBodyName : 'pressure_body';
 
   return (
-    <>
+    <Stack spacing={4}>
       <TagInputField
         label={t('settings.pressure.label.targets')}
         placeholder="Nome do alvo <nome@alvo.org>"
         name={prefix ? prefix + ".targets" : "targets"}
         validate={validate}
       />
-      <InputField
-        name={prefix ? prefix + `.${emailSubject}` : emailSubject}
-        placeholder={t('settings.pressure.placeholder.email_subject')}
-        label={t('settings.pressure.label.email_subject')}
-      />
+      <SpyField field="settings.is_subject_list">
+        {({ value }: { value: string }) => value === 'n'
+        ?
+          <InputField
+            name={prefix ? prefix + `.${emailSubject}` : emailSubject}
+            placeholder={t('settings.pressure.placeholder.email_subject')}
+            label={t('settings.pressure.label.email_subject')}
+          />
+         : 
+          <TagInputField
+            label={t('settings.pressure.label.email_subject')}
+            name={prefix ? prefix + '.subject_list' : '.subject_list'}
+            placeholder={t('settings.pressure.placeholder.is_subject_list')}
+          />
+        }
+      </SpyField>
       <TextareaField
         name={prefix ? prefix + `.${emailBody}` : emailBody}
         placeholder={t('settings.pressure.placeholder.email_body')}
         label={t('settings.pressure.label.email_body')}
       />
-    </>
+    </Stack>
   );
 }
 

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Pressure/ConfigurePressureTargets/TagInputField.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Pressure/ConfigurePressureTargets/TagInputField.tsx
@@ -146,7 +146,7 @@ export interface TagInputFieldProps {
   name: string
   label?: string
   placeholder?: string
-  validate: (value?: any, allValues?: any, meta?: any) => any
+  validate?: (value?: any, allValues?: any, meta?: any) => any
 }
 
 const TagInputField: React.FC<TagInputFieldProps> = ({ name, validate, ...props }) => {

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Pressure/ConfigurePressureTargets/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Pressure/ConfigurePressureTargets/index.tsx
@@ -78,7 +78,8 @@ const ConfigurePressureTargets = ({ widget, updateCache }: Props): React.ReactEl
       initialValues={{
         settings: {
           ...widget.settings,
-          pressure_type: widget.settings.pressure_type || 'unique'
+          pressure_type: widget.settings.pressure_type || 'unique',
+          is_subject_list: widget.settings.is_subject_list || 'n'
         },
         groups: widget.groups
       }}
@@ -124,6 +125,7 @@ const ConfigurePressureTargets = ({ widget, updateCache }: Props): React.ReactEl
                         Defina abaixo quem serão os alvos da sua campanha de pressão e o e-mail que será enviado para eles:
                       </Text>
                     </Stack>
+
                     <RadioField
                       name='settings.pressure_type'
                       label={t('settings.pressure.label.pressure_type')}
@@ -133,8 +135,18 @@ const ConfigurePressureTargets = ({ widget, updateCache }: Props): React.ReactEl
                     </RadioField>
 
                     {value === 'unique'
-                      ? <UniqueFormFields />
-                      : <GroupFormFields form={form} />
+                      ? (
+                        <>
+                          <RadioField
+                            name='settings.is_subject_list'
+                            label={t('settings.pressure.label.is_subject_list')}
+                          >
+                            <Radio value='s'>{t('settings.pressure.radio.yes')}</Radio>
+                            <Radio value='n'>{t('settings.pressure.radio.no')}</Radio>
+                          </RadioField>
+                          <UniqueFormFields />
+                        </>
+                      ) : <GroupFormFields form={form} />
                     }
 
                     <RadioField

--- a/clients/packages/webpage-client/src/activists/pressure.spec.ts
+++ b/clients/packages/webpage-client/src/activists/pressure.spec.ts
@@ -26,7 +26,8 @@ describe('activists module pressure tests', () => {
       }
     },
     widget: {
-      id: 345
+      id: 345,
+      settings: {}
     }
   };
   const OLD_ENV = process.env;

--- a/clients/packages/webpage-client/src/activists/pressure.ts
+++ b/clients/packages/webpage-client/src/activists/pressure.ts
@@ -19,6 +19,7 @@ export type Payload = {
 
 export type Widget = {
   id: number;
+  settings: any;
 };
 
 export interface Args {
@@ -57,7 +58,7 @@ const pressure = async ({ payload, widget }: Args): Promise<any> => {
       token: jwt.sign({}, process.env.ACTION_SECRET_KEY || ''),
     };
 
-    if (mail.disableEditField !== 's') {
+    if (mail.disableEditField !== 's' || widget.settings.is_subject_list === 's') {
       pressureInput.email_subject = mail.subject;
       pressureInput.email_body = mail.body;
     }

--- a/clients/packages/webpage-client/src/activists/pressure.ts
+++ b/clients/packages/webpage-client/src/activists/pressure.ts
@@ -62,13 +62,6 @@ const pressure = async ({ payload, widget }: Args): Promise<any> => {
       pressureInput.email_body = mail.body;
     }
 
-    // Teste de pressões com assuntos randomicos
-    if (widget.id == 75246) {
-    // if (widget.id == 23194) {
-      pressureInput.email_subject = mail.subject;
-      pressureInput.email_body = mail.body;
-    }
-
     const variables = {
       activist: input,
       widget_id: widget.id,

--- a/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
+++ b/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
@@ -43,6 +43,8 @@ type Props = {
       pressure_type?: string | 'unique' | 'group';
       select_label?: string;
       show_state?: string;
+      is_subject_list?: string | 's' | 'n';
+      subject_list?: string[]
     };
   };
   BeforeStandardFields?: any;
@@ -67,7 +69,8 @@ const PressureForm = ({
       show_state: showState,
       main_color: buttonColor,
       button_text: buttonText,
-      // pressure_subject: subject = '',
+      is_subject_list: isSubjectList = 'n',
+      subject_list: subjectList = [],
       pressure_body: body = '',
       pressure_type,
       select_label,
@@ -88,37 +91,12 @@ const PressureForm = ({
     }
   } = widget;
 
-  if (widget.id == 75246) {
-  // if (widget.id == 23194) {
-    const random_subjects_list = [
-      "Ministro Lewandowski, o Brasil conta com você",
-      "Queremos o fim do Orçamento Secreto",
-      "Ministro, conto com você pelo fim do Orçamento Secreto",
-      "Queremos transparência nos gastos públicos",
-      "Contamos com o seu voto pelo fim do Orçamento Secreto",
-      "Caro Ministro, você pode dar um presente para os brasileiros",
-      "O Orçamento Secreto não pode continuar!",
-      "Fim do Orçamento Secreto Já, Ministro!",
-      "Excelentíssimo Ministro, a corrupção não pode prevalecer!",
-      "Ministro Lewandowski, o maior escândalo de corrupção tá em suas mãos",
-      "O seu voto pode salvar a nossa democracia, Ministro",
-      "Mais transparência para o país",
-      "Transparência no orçamento público",
-      "Julgamento do Orçamento Secreto",
-      "Ministro, o Brasil precisa do seu voto",
-      "Democracia com transparência",
-      "Ministro Lewandowski, vote pela transparência!",
-      "Ministro, eu quero o fim do orçamento secreto",
-      "A transparência nos gastos está nas suas mãos, Ministro",
-      "Ministro, contamos com o senhor",
-      "Ministro, o seu voto é nossa última chance"
-    ];
-
+  if (isSubjectList === 's') {
     const min = Math.ceil(0);
-    const max = Math.floor(random_subjects_list.length - 1);
+    const max = Math.floor(subjectList.length - 1);
     const position = Math.floor(Math.random() * (max - min + 1)) + min;
 
-    subject = random_subjects_list[position] as string
+    subject = subjectList[position] as string
   }
 
   return (

--- a/clients/packages/webpage-client/src/pages/api/actions/pressure.ts
+++ b/clients/packages/webpage-client/src/pages/api/actions/pressure.ts
@@ -23,6 +23,7 @@ export type Payload = {
 
 export type Widget = {
   id: number;
+  settings: any;
 };
 
 export interface Args {


### PR DESCRIPTION
Mobilizador pode escolher na configuração de pressão a opção de adicionar vários assuntos que serão enviados de maneira randomizada aos alvos.