### PR TITLE
WIP: Removed keys from Next public config

### DIFF
--- a/clients/libs/ckeditor5-custom-build/README.md
+++ b/clients/libs/ckeditor5-custom-build/README.md
@@ -49,7 +49,11 @@ Follow the guides available on https://ckeditor.com/docs/ckeditor5/latest/framew
 ## FAQ
 | Where is the place to report bugs and feature requests?
 
+<<<<<<< HEAD
 You can create an issue on https://github.com/ckeditor/ckeditor5/issues including the build id - `93okfd2y7ie6-b0yvsfceumgh`. Make sure that the question / problem is unique, please look for a possibly asked questions in the search box. Duplicates will be closed.
+=======
+You can create an issue on https://github.com/ckeditor/ckeditor5/issues including the build id - `kxlsmp5j63dq-wbhgbegb0n5t`. Make sure that the question / problem is unique, please look for a possibly asked questions in the search box. Duplicates will be closed.
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 
 | Where can I learn more about the CKEditor 5 framework?
 

--- a/clients/libs/ckeditor5-custom-build/package.json
+++ b/clients/libs/ckeditor5-custom-build/package.json
@@ -11,23 +11,35 @@
     "@ckeditor/ckeditor5-alignment": "41.4.2",
     "@ckeditor/ckeditor5-basic-styles": "41.4.2",
     "@ckeditor/ckeditor5-block-quote": "41.4.2",
+<<<<<<< HEAD
     "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+=======
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
     "@ckeditor/ckeditor5-editor-classic": "41.4.2",
     "@ckeditor/ckeditor5-essentials": "41.4.2",
     "@ckeditor/ckeditor5-font": "41.4.2",
     "@ckeditor/ckeditor5-heading": "41.4.2",
+<<<<<<< HEAD
     "@ckeditor/ckeditor5-html-support": "41.4.2",
+=======
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
     "@ckeditor/ckeditor5-image": "41.4.2",
     "@ckeditor/ckeditor5-indent": "41.4.2",
     "@ckeditor/ckeditor5-link": "41.4.2",
     "@ckeditor/ckeditor5-list": "41.4.2",
     "@ckeditor/ckeditor5-media-embed": "41.4.2",
     "@ckeditor/ckeditor5-paragraph": "41.4.2",
+<<<<<<< HEAD
     "@ckeditor/ckeditor5-special-characters": "41.4.2",
     "@ckeditor/ckeditor5-style": "41.4.2",
     "@ckeditor/ckeditor5-table": "41.4.2",
     "@ckeditor/ckeditor5-undo": "41.4.2",
     "@ckeditor/ckeditor5-upload": "41.4.2"
+=======
+    "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+    "@ckeditor/ckeditor5-table": "41.4.2",
+    "@ckeditor/ckeditor5-undo": "41.4.2"
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-core": "41.4.2",
@@ -46,7 +58,10 @@
     "webpack-cli": "^4.10.0"
   },
   "scripts": {
+<<<<<<< HEAD
     "prepare": "webpack --mode production",
+=======
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
     "build": "webpack --mode production",
     "postbuild": "tsc --declaration --declarationDir build --stripInternal --emitDeclarationOnly"
   }

--- a/clients/libs/ckeditor5-custom-build/sample/script.js
+++ b/clients/libs/ckeditor5-custom-build/sample/script.js
@@ -12,7 +12,11 @@ function handleSampleError( error ) {
 
 	const message = [
 		'Oops, something went wrong!',
+<<<<<<< HEAD
 		`Please, report the following error on ${ issueUrl } with the build id "93okfd2y7ie6-b0yvsfceumgh" and the error stack trace:`
+=======
+		`Please, report the following error on ${ issueUrl } with the build id "kxlsmp5j63dq-wbhgbegb0n5t" and the error stack trace:`
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 	].join( '\n' );
 
 	console.error( message );

--- a/clients/libs/ckeditor5-custom-build/src/ckeditor.ts
+++ b/clients/libs/ckeditor5-custom-build/src/ckeditor.ts
@@ -6,6 +6,7 @@
 import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 
 import { Alignment } from '@ckeditor/ckeditor5-alignment';
+<<<<<<< HEAD
 import { Bold, Italic, Underline } from '@ckeditor/ckeditor5-basic-styles';
 import { BlockQuote } from '@ckeditor/ckeditor5-block-quote';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
@@ -19,11 +20,23 @@ import {
 	ImageCaption,
 	ImageInsert,
 	ImageResize,
+=======
+import { Bold, Italic } from '@ckeditor/ckeditor5-basic-styles';
+import { BlockQuote } from '@ckeditor/ckeditor5-block-quote';
+import type { EditorConfig } from '@ckeditor/ckeditor5-core';
+import { Essentials } from '@ckeditor/ckeditor5-essentials';
+import { FontColor, FontFamily, FontSize } from '@ckeditor/ckeditor5-font';
+import { Heading } from '@ckeditor/ckeditor5-heading';
+import {
+	Image,
+	ImageCaption,
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 	ImageStyle,
 	ImageToolbar,
 	ImageUpload
 } from '@ckeditor/ckeditor5-image';
 import { Indent } from '@ckeditor/ckeditor5-indent';
+<<<<<<< HEAD
 import { AutoLink, Link, LinkImage } from '@ckeditor/ckeditor5-link';
 import { List } from '@ckeditor/ckeditor5-list';
 import { MediaEmbed, MediaEmbedToolbar } from '@ckeditor/ckeditor5-media-embed';
@@ -33,6 +46,15 @@ import { Style } from '@ckeditor/ckeditor5-style';
 import { Table, TableCaption } from '@ckeditor/ckeditor5-table';
 import { Undo } from '@ckeditor/ckeditor5-undo';
 import { S3Upload } from './s3upload';
+=======
+import { Link } from '@ckeditor/ckeditor5-link';
+import { List } from '@ckeditor/ckeditor5-list';
+import { MediaEmbed } from '@ckeditor/ckeditor5-media-embed';
+import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import { PasteFromOffice } from '@ckeditor/ckeditor5-paste-from-office';
+import { Table, TableToolbar } from '@ckeditor/ckeditor5-table';
+import { Undo } from '@ckeditor/ckeditor5-undo';
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 
 // You can read more about extending the build with additional plugins in the "Installing plugins" guide.
 // See https://ckeditor.com/docs/ckeditor5/latest/installation/plugins/installing-plugins.html for details.
@@ -40,6 +62,7 @@ import { S3Upload } from './s3upload';
 class Editor extends ClassicEditor {
 	public static override builtinPlugins = [
 		Alignment,
+<<<<<<< HEAD
 		AutoLink,
 		BlockQuote,
 		Bold,
@@ -55,12 +78,24 @@ class Editor extends ClassicEditor {
 		ImageCaption,
 		ImageInsert,
 		ImageResize,
+=======
+		BlockQuote,
+		Bold,
+		Essentials,
+		FontColor,
+		FontFamily,
+		FontSize,
+		Heading,
+		Image,
+		ImageCaption,
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 		ImageStyle,
 		ImageToolbar,
 		ImageUpload,
 		Indent,
 		Italic,
 		Link,
+<<<<<<< HEAD
 		LinkImage,
 		List,
 		MediaEmbed,
@@ -72,19 +107,31 @@ class Editor extends ClassicEditor {
 		Table,
 		TableCaption,
 		Underline,
+=======
+		List,
+		MediaEmbed,
+		Paragraph,
+		PasteFromOffice,
+		Table,
+		TableToolbar,
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 		Undo
 	];
 
 	public static override defaultConfig: EditorConfig = {
 		toolbar: {
 			items: [
+<<<<<<< HEAD
 				'undo',
 				'redo',
 				'|',
+=======
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 				'heading',
 				'|',
 				'bold',
 				'italic',
+<<<<<<< HEAD
 				'underline',
 				'blockQuote',
 				'alignment',
@@ -113,14 +160,48 @@ class Editor extends ClassicEditor {
 					{ model: 'heading3', view: 'h3', title: 'Heading 3', class: 'ck-heading_heading3' }
 			]
 		},
+=======
+				'fontFamily',
+				'fontSize',
+				'fontColor',
+				'link',
+				'|',
+				'alignment',
+				'bulletedList',
+				'numberedList',
+				'|',
+				'outdent',
+				'indent',
+				'|',
+				'imageUpload',
+				'blockQuote',
+				'insertTable',
+				'mediaEmbed',
+				'undo',
+				'redo'
+			]
+		},
+		language: 'pt-br',
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 		image: {
 			toolbar: [
 				'imageTextAlternative',
 				'toggleImageCaption',
 				'imageStyle:inline',
 				'imageStyle:block',
+<<<<<<< HEAD
 				'imageStyle:side',
 				'linkImage'
+=======
+				'imageStyle:side'
+			]
+		},
+		table: {
+			contentToolbar: [
+				'tableColumn',
+				'tableRow',
+				'mergeTableCells'
+>>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 			]
 		}
 	};

--- a/clients/libs/ckeditor5-custom-build/src/ckeditor.ts
+++ b/clients/libs/ckeditor5-custom-build/src/ckeditor.ts
@@ -6,7 +6,6 @@
 import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 
 import { Alignment } from '@ckeditor/ckeditor5-alignment';
-<<<<<<< HEAD
 import { Bold, Italic, Underline } from '@ckeditor/ckeditor5-basic-styles';
 import { BlockQuote } from '@ckeditor/ckeditor5-block-quote';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
@@ -20,23 +19,11 @@ import {
 	ImageCaption,
 	ImageInsert,
 	ImageResize,
-=======
-import { Bold, Italic } from '@ckeditor/ckeditor5-basic-styles';
-import { BlockQuote } from '@ckeditor/ckeditor5-block-quote';
-import type { EditorConfig } from '@ckeditor/ckeditor5-core';
-import { Essentials } from '@ckeditor/ckeditor5-essentials';
-import { FontColor, FontFamily, FontSize } from '@ckeditor/ckeditor5-font';
-import { Heading } from '@ckeditor/ckeditor5-heading';
-import {
-	Image,
-	ImageCaption,
->>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 	ImageStyle,
 	ImageToolbar,
 	ImageUpload
 } from '@ckeditor/ckeditor5-image';
 import { Indent } from '@ckeditor/ckeditor5-indent';
-<<<<<<< HEAD
 import { AutoLink, Link, LinkImage } from '@ckeditor/ckeditor5-link';
 import { List } from '@ckeditor/ckeditor5-list';
 import { MediaEmbed, MediaEmbedToolbar } from '@ckeditor/ckeditor5-media-embed';
@@ -46,15 +33,6 @@ import { Style } from '@ckeditor/ckeditor5-style';
 import { Table, TableCaption } from '@ckeditor/ckeditor5-table';
 import { Undo } from '@ckeditor/ckeditor5-undo';
 import { S3Upload } from './s3upload';
-=======
-import { Link } from '@ckeditor/ckeditor5-link';
-import { List } from '@ckeditor/ckeditor5-list';
-import { MediaEmbed } from '@ckeditor/ckeditor5-media-embed';
-import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
-import { PasteFromOffice } from '@ckeditor/ckeditor5-paste-from-office';
-import { Table, TableToolbar } from '@ckeditor/ckeditor5-table';
-import { Undo } from '@ckeditor/ckeditor5-undo';
->>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 
 // You can read more about extending the build with additional plugins in the "Installing plugins" guide.
 // See https://ckeditor.com/docs/ckeditor5/latest/installation/plugins/installing-plugins.html for details.
@@ -62,7 +40,6 @@ import { Undo } from '@ckeditor/ckeditor5-undo';
 class Editor extends ClassicEditor {
 	public static override builtinPlugins = [
 		Alignment,
-<<<<<<< HEAD
 		AutoLink,
 		BlockQuote,
 		Bold,
@@ -78,24 +55,12 @@ class Editor extends ClassicEditor {
 		ImageCaption,
 		ImageInsert,
 		ImageResize,
-=======
-		BlockQuote,
-		Bold,
-		Essentials,
-		FontColor,
-		FontFamily,
-		FontSize,
-		Heading,
-		Image,
-		ImageCaption,
->>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 		ImageStyle,
 		ImageToolbar,
 		ImageUpload,
 		Indent,
 		Italic,
 		Link,
-<<<<<<< HEAD
 		LinkImage,
 		List,
 		MediaEmbed,
@@ -107,31 +72,19 @@ class Editor extends ClassicEditor {
 		Table,
 		TableCaption,
 		Underline,
-=======
-		List,
-		MediaEmbed,
-		Paragraph,
-		PasteFromOffice,
-		Table,
-		TableToolbar,
->>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 		Undo
 	];
 
 	public static override defaultConfig: EditorConfig = {
 		toolbar: {
 			items: [
-<<<<<<< HEAD
 				'undo',
 				'redo',
 				'|',
-=======
->>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 				'heading',
 				'|',
 				'bold',
 				'italic',
-<<<<<<< HEAD
 				'underline',
 				'blockQuote',
 				'alignment',
@@ -160,48 +113,14 @@ class Editor extends ClassicEditor {
 					{ model: 'heading3', view: 'h3', title: 'Heading 3', class: 'ck-heading_heading3' }
 			]
 		},
-=======
-				'fontFamily',
-				'fontSize',
-				'fontColor',
-				'link',
-				'|',
-				'alignment',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'imageUpload',
-				'blockQuote',
-				'insertTable',
-				'mediaEmbed',
-				'undo',
-				'redo'
-			]
-		},
-		language: 'pt-br',
->>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 		image: {
 			toolbar: [
 				'imageTextAlternative',
 				'toggleImageCaption',
 				'imageStyle:inline',
 				'imageStyle:block',
-<<<<<<< HEAD
 				'imageStyle:side',
 				'linkImage'
-=======
-				'imageStyle:side'
-			]
-		},
-		table: {
-			contentToolbar: [
-				'tableColumn',
-				'tableRow',
-				'mergeTableCells'
->>>>>>> 63416bc39 (feat: add ckeditor to autofire)
 			]
 		}
 	};

--- a/clients/packages/canary-client/package-lock.json
+++ b/clients/packages/canary-client/package-lock.json
@@ -1,0 +1,1870 @@
+{
+  "name": "canary-client",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-41.4.2.tgz",
+      "integrity": "sha512-yXVVEy+lEmyvYwTxn76Ff53fK/qJphf9stoBF4kFKKK/Tfi59EMog2Ctk3iIkLLyt74KmxzvuCXZwE00wDqfLA==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-autoformat": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-41.4.2.tgz",
+      "integrity": "sha512-Ukit63jHiAuLyfESdLSc6ya12xKJxDP83krZFiMY5bfXssg0z39CGuHOZlwaI9r7bBjWWMGJJeaC/9i/6L9y7g==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-basic-styles": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-41.4.2.tgz",
+      "integrity": "sha512-+Y+M9/JRX3xSHX/E5zFwzuKPzEeeuL61wcig1DuEz7GvK5sRLJcbdVQmiJnfDh3iOcf/ob1nahNgHAEoCno0Dw==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-block-quote": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-41.4.2.tgz",
+      "integrity": "sha512-tkEKd3pmDO8QWm243FRDRUv5COayXYZJpMFUL6blw3m6IXb4ujcXKn61A+UwUO+kM0NGTuepHZJkFSuV1/90sw==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-build-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-balloon/-/ckeditor5-build-balloon-41.4.2.tgz",
+      "integrity": "sha512-4FLvd2OV4UgPva0/+xHT4ZuEzKLxB9M6D04/G0YFFwvbPiy71zH0iEMj132Wd0fdEJ0fwjF1HfDzhNgI9BPhPA==",
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      },
+      "dependencies": {
+        "@ckeditor/ckeditor5-image": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
+          "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        },
+        "@ckeditor/ckeditor5-media-embed": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
+          "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-table": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
+          "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        }
+      }
+    },
+    "@ckeditor/ckeditor5-build-balloon-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-balloon-block/-/ckeditor5-build-balloon-block-41.4.2.tgz",
+      "integrity": "sha512-p2pXJcS0hNuDZXyMi0frSwLZBm1hGGEEajJtAvKdg+pKZvvrIabQzvjtrkUf5P6Lbhl/z1/v2h0pBa76025Q5Q==",
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      },
+      "dependencies": {
+        "@ckeditor/ckeditor5-image": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
+          "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        },
+        "@ckeditor/ckeditor5-media-embed": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
+          "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-table": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
+          "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        }
+      }
+    },
+    "@ckeditor/ckeditor5-build-classic": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-41.4.2.tgz",
+      "integrity": "sha512-fdsxmEPdNdo/usXyYMS2cN/E9KcQIrtmImUYDI+jEs6yzmSgI8By01n+enkKgVxu+2t+g+ctjQwrCpiyWIHTAQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-build-decoupled-document": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-decoupled-document/-/ckeditor5-build-decoupled-document-41.4.2.tgz",
+      "integrity": "sha512-YIjcJc9flghFsA5gZaL5oIf6TxLJxUZpXgWYa9l5C68enm36bsDycgJWGGbexHK2HOR9AnBr6ThUBQJkn3StTg==",
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      },
+      "dependencies": {
+        "@ckeditor/ckeditor5-alignment": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+          "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+          "requires": {
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-font": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+          "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+          "requires": {
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-image": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
+          "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        },
+        "@ckeditor/ckeditor5-media-embed": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
+          "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-table": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
+          "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        }
+      }
+    },
+    "@ckeditor/ckeditor5-build-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-inline/-/ckeditor5-build-inline-41.4.2.tgz",
+      "integrity": "sha512-h57jjFm0cSOFGSTA2MbvhSXMFxUbPZqwIeA9S0bfUNcGrnm84YaerX8ev8ZP2iMLOckPOcjBiC/70Sp0SvGwxg==",
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      },
+      "dependencies": {
+        "@ckeditor/ckeditor5-image": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
+          "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        },
+        "@ckeditor/ckeditor5-media-embed": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
+          "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-table": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
+          "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        }
+      }
+    },
+    "@ckeditor/ckeditor5-build-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-multi-root/-/ckeditor5-build-multi-root-41.4.2.tgz",
+      "integrity": "sha512-Hou3cHuzx2YR6cfbTYYgk2cSBkudCfPru471KxsXUtzw+B7KuHLm3LtnLJNpScF2WoGaOoaFzB9D2PkzlhF5hA==",
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      },
+      "dependencies": {
+        "@ckeditor/ckeditor5-image": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
+          "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        },
+        "@ckeditor/ckeditor5-media-embed": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
+          "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-table": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
+          "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        }
+      }
+    },
+    "@ckeditor/ckeditor5-ckbox": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-41.4.2.tgz",
+      "integrity": "sha512-u6HVTW7O+YSeeCZ+plg78aW74B2G+E7uKy5YQxvB99uCXGWmYy57D2maaEkPI87ZwZD3VlRnvAalaAdngc4M1g==",
+      "requires": {
+        "blurhash": "2.0.5",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-ckfinder": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-41.4.2.tgz",
+      "integrity": "sha512-QB3igdZOBI+I8q6eTA5+q27VQrj3Nu7PctNKRehwMC/Z6URboTnntqtkZ3inAZEbWcoLTN2tpDthlufUbQ+cfA==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-cloud-services": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-41.4.2.tgz",
+      "integrity": "sha512-rgDrpEonA2AchfvgYaeb/olMk/HYxUK4B8XPqs+nJxLmBraTv2lANsgsMbwsqAIiRjT9MknmJdX+CEbqljgL/w==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-core": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-41.4.2.tgz",
+      "integrity": "sha512-kCIJjviiMNIMBMx7XFXFp1IeTELQKv7xyPJiVFDyUftIfthf9uWty72ipZ3BBNBGBkaoTiSzDZ507EsX6czuIQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-easy-image": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-41.4.2.tgz",
+      "integrity": "sha512-HJJ3Z4R4mCazV2cz+s8bI00ci3/KyIa+fXodBN1+kg3PldX471zSj+DtyFsZyKnUcpUTVygjPEaHKBDpxtUhjQ==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-classic": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-41.4.2.tgz",
+      "integrity": "sha512-BVf4ipZz36eCTDFiQ8hqN+oBmuvZPzCmNDDjCYuHNGCKGLaIo1Yzi09fHPUWDw1U+en6Cgnwc2HSWgwf7zC7aA==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-engine": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-41.4.2.tgz",
+      "integrity": "sha512-25JqIzNYvCqQ6f02YY+a8A8xtjClzI0YCio0JGoRG3JHJXzYsQbTPsiokuE1BCwMCu3gYoFz8eKJYt2selLsCw==",
+      "requires": {
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-essentials": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-41.4.2.tgz",
+      "integrity": "sha512-1UCvk76v2+NDfHfTo3Qg0EJYpddgSC/i66jY3NnQUFt1zt68rAzm/kFOVYjTD/QDn6pyiMAIUeMlKFkswF+upg==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-heading": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-41.4.2.tgz",
+      "integrity": "sha512-8AyMumy90nY49reQlHuCgSJFSaym4emCVF6vAAqd71FHtmgtfS9w3xMqXAk6QbgMjfy46cwind0JITZfBfKqLg==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-image": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
+      "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-indent": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-41.4.2.tgz",
+      "integrity": "sha512-pghHa+DKya6788nTiU1ZItKmAgjf+up4Rqe5GOkxKB7vJc189KSBJYc5foov65nM831rXcWgTk4jybK+JGHmjQ==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-link": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-41.4.2.tgz",
+      "integrity": "sha512-woMv9/BxkDjG5xsS/OyaxW9tWTuiG6wZWWcYxVJq8FOW2NL68CKQLmyoQ1rdv/2Gw4UPUXTtB+1uGVmQDMXDsQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-list": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-41.4.2.tgz",
+      "integrity": "sha512-nGb36jNJO6YAU35piKabey9B13xw6TnmL5VySS2dEqSt/DTy7RdY5z2K7CU/NGuIGe/bPBZgU1J0dQkRr2F3hA==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "@ckeditor/ckeditor5-media-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
+      "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-paragraph": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-41.4.2.tgz",
+      "integrity": "sha512-tOsD40Fcqli5zkH/68WhcqYU8BL4qb8J5xGuk1xmBokz3W0LzebWW0GXmFk5PmWv+fg0dOXfSo8uMzb5ni+CuQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-paste-from-office": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-41.4.2.tgz",
+      "integrity": "sha512-jby5YQ2QowGdDCshPq5Ej11wTFcBZP2dYhQTu6fRZRc+mdihKCILxh0rwBgBOCCf+buflx8RYp/WKd76Kcuq5g==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "requires": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-table": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
+      "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-typing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-41.4.2.tgz",
+      "integrity": "sha512-dXP+uNl+jkfrSIqMNai2yakR/3JqJ9g0M9WwwnV5vzbEOKD4YKP5+ixvqKb39dwLCLZ4mGpJaX+rjNXBExjSIw==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-ui": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-41.4.2.tgz",
+      "integrity": "sha512-wvRbDXJN8PmaWyB0H487DjvdH2ayMyN52+WLkZlVbhX9ICb1sf5XnLz4v/wXeQ4W8JbWdsg2FZIDDQDeXjvyJw==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "color-convert": "2.0.1",
+        "color-parse": "1.4.2",
+        "lodash-es": "4.17.21",
+        "vanilla-colorful": "0.7.2"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
+    "@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "@ckeditor/ckeditor5-utils": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-41.4.2.tgz",
+      "integrity": "sha512-VgLr2eLVggyhDqa7H8JUxpnOLTZ0R/YuDZ6ENVUumd9q4VrpNs94ZK0Y/Shp7UmuHQ/sTth+PWTsi+t5KwYqeQ==",
+      "requires": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "requires": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "requires": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+    },
+    "@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
+    "abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+    },
+    "acorn": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw=="
+    },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        }
+      }
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
+    "blurhash": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
+      "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w=="
+    },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      },
+      "dependencies": {
+        "@ckeditor/ckeditor5-alignment": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+          "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+          "requires": {
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-build-classic": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-41.4.2.tgz",
+          "integrity": "sha512-fdsxmEPdNdo/usXyYMS2cN/E9KcQIrtmImUYDI+jEs6yzmSgI8By01n+enkKgVxu+2t+g+ctjQwrCpiyWIHTAQ==",
+          "requires": {
+            "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+            "@ckeditor/ckeditor5-autoformat": "41.4.2",
+            "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+            "@ckeditor/ckeditor5-block-quote": "41.4.2",
+            "@ckeditor/ckeditor5-ckbox": "41.4.2",
+            "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+            "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+            "@ckeditor/ckeditor5-easy-image": "41.4.2",
+            "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+            "@ckeditor/ckeditor5-essentials": "41.4.2",
+            "@ckeditor/ckeditor5-heading": "41.4.2",
+            "@ckeditor/ckeditor5-image": "41.4.2",
+            "@ckeditor/ckeditor5-indent": "41.4.2",
+            "@ckeditor/ckeditor5-link": "41.4.2",
+            "@ckeditor/ckeditor5-list": "41.4.2",
+            "@ckeditor/ckeditor5-media-embed": "41.4.2",
+            "@ckeditor/ckeditor5-paragraph": "41.4.2",
+            "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+            "@ckeditor/ckeditor5-table": "41.4.2",
+            "@ckeditor/ckeditor5-typing": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-font": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+          "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+          "requires": {
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-image": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
+          "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        },
+        "@ckeditor/ckeditor5-media-embed": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
+          "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2"
+          }
+        },
+        "@ckeditor/ckeditor5-table": {
+          "version": "41.4.2",
+          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
+          "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
+          "requires": {
+            "@ckeditor/ckeditor5-ui": "41.4.2",
+            "ckeditor5": "41.4.2",
+            "lodash-es": "4.17.21"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "color-parse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
+      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "requires": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      }
+    },
+    "css-loader": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
+      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.33",
+        "postcss-modules-extract-imports": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.5",
+        "postcss-modules-scope": "^3.2.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.5.4"
+      }
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
+    },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+        }
+      }
+    },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      }
+    },
+    "debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+        }
+      }
+    },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+    },
+    "env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "source-map": "~0.6.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
+    "jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "jsdom": {
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
+      "requires": {
+        "abab": "^2.0.5",
+        "acorn": "^8.2.4",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.6",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      }
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
+    "marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true
+    },
+    "nwsapi": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
+      "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ=="
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "picocolors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "dev": true
+    },
+    "postcss": {
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "postcss-loader": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-8.1.1.tgz",
+      "integrity": "sha512-0IeqyAsG6tYiDRCYKQJLAmgQr47DX6N7sFSWvQxt6AcupX8DIdmykuk/o/tx0Lze3ErGHJEp5OSRxrelC6+NdQ==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^9.0.0",
+        "jiti": "^1.20.0",
+        "semver": "^7.5.4"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "dev": true
+    },
+    "postcss-modules-local-by-default": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.5.tgz",
+      "integrity": "sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.0.tgz",
+      "integrity": "sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.0.4"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.0.0"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
+      "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
+    "punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "raw-loader": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
+    },
+    "schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "requires": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      }
+    },
+    "semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true
+    },
+    "source-map-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "dev": true
+    },
+    "style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      }
+    },
+    "tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "turndown": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-6.0.0.tgz",
+      "integrity": "sha512-UVJBhSyRHCpNKtQ00mNWlYUM/i+tcipkb++F0PrOpt0L7EhNd0AX9mWEpL2dRFBu7LWXMp4HgAMA4OeKKnN7og==",
+      "requires": {
+        "jsdom": "^16.2.0"
+      }
+    },
+    "turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="
+    },
+    "universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "vanilla-colorful": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
+      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg=="
+    },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+    },
+    "whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "requires": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    }
+  }
+}

--- a/clients/packages/canary-client/src/components/CustomCKEditor.tsx
+++ b/clients/packages/canary-client/src/components/CustomCKEditor.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { CKEditor } from '@ckeditor/ckeditor5-react';
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+
+// import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
+import Alignment from '@ckeditor/ckeditor5-alignment/src/alignment';
+// import Font from '@ckeditor/ckeditor5-font/src/font';
+
+
+const editorConfiguration = {
+  plugins: [Underline, Alignment, Font],
+  toolbar: [ 'bold', 'italic' ]
+};
+
+
+const CustomEditorBase = () => {
+  const [editorData, setEditorData] = useState('');
+
+  return (
+    <div>
+      <CKEditor
+        editor={ClassicEditor}
+        data={editorData}
+        config={{
+          plugins: [Alignment, Font],
+          toolbar: [
+            'heading', '|',
+            'bold', 'italic', 'underline', 'link', '|',
+            'bulletedList', 'numberedList', '|',
+            'insertTable', 'blockQuote', 'mediaEmbed', '|',
+            'alignment', '|',
+            'fontColor', 'fontBackgroundColor', '|',
+            'imageUpload', 'insertButton'
+          ],
+          image: {
+            toolbar: [
+              'imageTextAlternative', 'imageStyle:full', 'imageStyle:side'
+            ]
+          },
+          table: {
+            contentToolbar: [
+              'tableColumn', 'tableRow', 'mergeTableCells'
+            ]
+          },
+        }}
+        onReady={editor => {
+          console.log('Editor is ready to use!', editor);
+        }}
+        onChange={(event, editor) => {
+          const data = editor.getData();
+          setEditorData(data);
+          console.log({ event, editor, data });
+        }}
+        onBlur={(event, editor) => {
+          console.log('Blur.', editor);
+        }}
+        onFocus={(event, editor) => {
+          console.log('Focus.', editor);
+        }}
+      />
+    </div>
+  );
+};
+
+export default CustomEditorBase;

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
@@ -13,7 +13,6 @@ import {
 } from "bonde-components/chakra";
 
 
-
 import { noSpecialCharacters } from "../../../../services/utils";
 import { Widget } from "../../FetchWidgets";
 import SettingsForm from '../SettingsForm';

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
@@ -9,7 +9,8 @@ import {
   Flex,
   Grid,
   GridItem,
-  Heading
+  Heading,
+  FormLabel
 } from "bonde-components/chakra";
 
 
@@ -29,7 +30,6 @@ const Styles = styled.div`
     padding-bottom: 4px;
   }
 `
-
 
 type Props = {
   widget: Widget;

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
@@ -31,6 +31,7 @@ const Styles = styled.div`
   }
 `
 
+
 type Props = {
   widget: Widget;
   updateCache: any;

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Autofire/index.tsx
@@ -9,8 +9,7 @@ import {
   Flex,
   Grid,
   GridItem,
-  Heading,
-  FormLabel
+  Heading
 } from "bonde-components/chakra";
 
 

--- a/clients/packages/webpage-client/next.config.js
+++ b/clients/packages/webpage-client/next.config.js
@@ -25,17 +25,19 @@ module.exports = withTM(
     // So, the source code is "basePath-ready".
     // You can remove `basePath` if you don't need it.
     reactStrictMode: true,
+    // Variáveis acessíveis apenas no servidor (não expostas no cliente)
+    serverRuntimeConfig: {
+      apiGraphqlSecret: process.env.REACT_APP_API_GRAPHQL_SECRET,
+      pagarmeKey: process.env.REACT_APP_PAGARME_KEY,
+      openApiToken: process.env.REACT_APP_OPENAPI_TOKEN,
+    },
     publicRuntimeConfig: {
       domainImaginary: process.env.REACT_APP_DOMAIN_IMAGINARY,
       domainApiRest: process.env.REACT_APP_DOMAIN_API_REST,
       domainApiGraphql: process.env.REACT_APP_DOMAIN_API_GRAPHQL,
-      apiGraphqlSecret: process.env.REACT_APP_API_GRAPHQL_SECRET,
       domainApiGraphqlWs: process.env.REACT_APP_DOMAIN_API_GRAPHQL_WS,
       domainPublic: process.env.REACT_APP_DOMAIN_PUBLIC,
-      pagarmeKey: process.env.REACT_APP_PAGARME_KEY,
-      
       openApiUrl: process.env.REACT_APP_OPENAPI_URL,
-      openApiToken: process.env.REACT_APP_OPENAPI_TOKEN,
       openApiCampaignId: process.env.REACT_APP_OPENAPI_CAMPAIGN_ID
     },
   })

--- a/clients/packages/webpage-client/src/apis/graphql/index.ts
+++ b/clients/packages/webpage-client/src/apis/graphql/index.ts
@@ -18,7 +18,7 @@ const authLink = setContext((_, { headers }) => {
   return {
     headers: {
       ...headers,
-      // 'x-hasura-admin-secret': publicRuntimeConfig.apiGraphqlSecret
+      // 'x-hasura-admin-secret': serverRuntimeConfig.apiGraphqlSecret
       // authorization: token ? `Bearer ${token}` : "",
     }
   }

--- a/clients/packages/webpage-client/src/components/DonationConnected.tsx
+++ b/clients/packages/webpage-client/src/components/DonationConnected.tsx
@@ -13,7 +13,7 @@ import fetch from 'node-fetch';
 
 import Utils from '../Utils';
 
-const { publicRuntimeConfig } = getConfig();
+const { serverRuntimeConfig } = getConfig();
 
 // const mapDispatchToProps = () => ({
 //   createTransaction: async (args: any) =>
@@ -76,7 +76,7 @@ const DonationConnected = (props: any) =>
         })
       ).json()
     }
-    pagarmeKey={publicRuntimeConfig.pagarmeKey || 'setup env var'}
+    pagarmeKey={serverRuntimeConfig.pagarmeKey || 'setup env var'}
     donationComponent={DonationPlugin}
     analyticsEvents={DonationAnalytics}
     overrides={{
@@ -106,7 +106,7 @@ export default DonationConnected;
 // )((props: MobProps) => (
 //   <PagarMeCheckout
 //     {...props}
-//     pagarmeKey={publicRuntimeConfig.pagarmeKey || 'setup env var'}
+//     pagarmeKey={serverRuntimeConfig.pagarmeKey || 'setup env var'}
 //     donationComponent={DonationPlugin}
 //     analyticsEvents={DonationAnalytics}
 //     overrides={{

--- a/clients/packages/webpage-client/src/components/subscriptions/CreditCardForm/submit.ts
+++ b/clients/packages/webpage-client/src/components/subscriptions/CreditCardForm/submit.ts
@@ -1,7 +1,7 @@
 import getConfig from 'next/config';
 import recharge from '../../../apis/rest/recharge';
 
-const { publicRuntimeConfig } = getConfig();
+const { serverRuntimeConfig } = getConfig();
 
 const submit = (values: any) => {
   //
@@ -17,7 +17,7 @@ const submit = (values: any) => {
   //
   const promise = new Promise((resolve, reject) => {
     // eslint-disable-next-line
-    (window as any).PagarMe.encryption_key = publicRuntimeConfig.pagarmeKey;
+    (window as any).PagarMe.encryption_key = serverRuntimeConfig.pagarmeKey;
 
     // eslint-disable-next-line
     const card = new (window as any).PagarMe.creditCard();

--- a/clients/packages/webpage-client/src/pages/api/campaigns/[widget_id].ts
+++ b/clients/packages/webpage-client/src/pages/api/campaigns/[widget_id].ts
@@ -8,12 +8,9 @@ interface Request {
 }
 
 const {
-    publicRuntimeConfig: {
-        openApiUrl,
-        openApiToken,
-        openApiCampaignId
-    }
-} = getConfig()
+    publicRuntimeConfig: { openApiUrl, openApiCampaignId },
+    serverRuntimeConfig: { openApiToken }
+} = getConfig();
 
 const campaign_id = openApiCampaignId;
 

--- a/clients/packages/webpage-client/src/pages/api/phone/[widget_id]/create.ts
+++ b/clients/packages/webpage-client/src/pages/api/phone/[widget_id]/create.ts
@@ -15,12 +15,9 @@ interface Request {
 }
 
 const {
-    publicRuntimeConfig: {
-        openApiUrl,
-        openApiToken,
-        openApiCampaignId
-    }
-} = getConfig()
+    publicRuntimeConfig: { openApiUrl, openApiCampaignId },
+    serverRuntimeConfig: { openApiToken }
+} = getConfig();
 
 const campaign_id = openApiCampaignId;
 

--- a/clients/packages/webpage-client/src/pages/api/phone/call/[call_id]/status.ts
+++ b/clients/packages/webpage-client/src/pages/api/phone/call/[call_id]/status.ts
@@ -8,11 +8,11 @@ interface Request {
 }
 
 const {
-    publicRuntimeConfig: {
-        openApiUrl,
+    publicRuntimeConfig: { openApiUrl },
+    serverRuntimeConfig: { 
         // openApiToken
     }
-} = getConfig()
+} = getConfig();
 
 export default async (req: Request, res: any) => {
     if (req.method === 'GET') {


### PR DESCRIPTION
## Contexto
Algumas chaves privadas estão sendo impressas no HTML que fica acessível para o usuário final.

Essas chaves do Pagarme, os Tokens da API GraphQL e do Open API deveriam ser secretas. É necessário revisar a forma de como resolver isso, entendendo ser uma função da própria tecnologia NextJS e então atualizar as chaves de acesso aos serviços.

https://nextjs.org/docs/pages/api-reference/next-config-js/runtime-configuration

