### PR TITLE
Removed keys from Next public config

### DIFF
--- a/clients/packages/webpage-client/next.config.js
+++ b/clients/packages/webpage-client/next.config.js
@@ -25,17 +25,19 @@ module.exports = withTM(
     // So, the source code is "basePath-ready".
     // You can remove `basePath` if you don't need it.
     reactStrictMode: true,
+    // Variáveis acessíveis apenas no servidor (não expostas no cliente)
+    serverRuntimeConfig: {
+      apiGraphqlSecret: process.env.REACT_APP_API_GRAPHQL_SECRET,
+      pagarmeKey: process.env.REACT_APP_PAGARME_KEY,
+      openApiToken: process.env.REACT_APP_OPENAPI_TOKEN,
+    },
     publicRuntimeConfig: {
       domainImaginary: process.env.REACT_APP_DOMAIN_IMAGINARY,
       domainApiRest: process.env.REACT_APP_DOMAIN_API_REST,
       domainApiGraphql: process.env.REACT_APP_DOMAIN_API_GRAPHQL,
-      apiGraphqlSecret: process.env.REACT_APP_API_GRAPHQL_SECRET,
       domainApiGraphqlWs: process.env.REACT_APP_DOMAIN_API_GRAPHQL_WS,
       domainPublic: process.env.REACT_APP_DOMAIN_PUBLIC,
-      pagarmeKey: process.env.REACT_APP_PAGARME_KEY,
-      
       openApiUrl: process.env.REACT_APP_OPENAPI_URL,
-      openApiToken: process.env.REACT_APP_OPENAPI_TOKEN,
       openApiCampaignId: process.env.REACT_APP_OPENAPI_CAMPAIGN_ID
     },
   })

--- a/clients/packages/webpage-client/src/apis/graphql/index.ts
+++ b/clients/packages/webpage-client/src/apis/graphql/index.ts
@@ -18,7 +18,7 @@ const authLink = setContext((_, { headers }) => {
   return {
     headers: {
       ...headers,
-      // 'x-hasura-admin-secret': publicRuntimeConfig.apiGraphqlSecret
+      // 'x-hasura-admin-secret': serverRuntimeConfig.apiGraphqlSecret
       // authorization: token ? `Bearer ${token}` : "",
     }
   }

--- a/clients/packages/webpage-client/src/components/DonationConnected.tsx
+++ b/clients/packages/webpage-client/src/components/DonationConnected.tsx
@@ -13,7 +13,7 @@ import fetch from 'node-fetch';
 
 import Utils from '../Utils';
 
-const { publicRuntimeConfig } = getConfig();
+const { serverRuntimeConfig } = getConfig();
 
 // const mapDispatchToProps = () => ({
 //   createTransaction: async (args: any) =>
@@ -76,7 +76,7 @@ const DonationConnected = (props: any) =>
         })
       ).json()
     }
-    pagarmeKey={publicRuntimeConfig.pagarmeKey || 'setup env var'}
+    pagarmeKey={serverRuntimeConfig.pagarmeKey || 'setup env var'}
     donationComponent={DonationPlugin}
     analyticsEvents={DonationAnalytics}
     overrides={{
@@ -106,7 +106,7 @@ export default DonationConnected;
 // )((props: MobProps) => (
 //   <PagarMeCheckout
 //     {...props}
-//     pagarmeKey={publicRuntimeConfig.pagarmeKey || 'setup env var'}
+//     pagarmeKey={serverRuntimeConfig.pagarmeKey || 'setup env var'}
 //     donationComponent={DonationPlugin}
 //     analyticsEvents={DonationAnalytics}
 //     overrides={{

--- a/clients/packages/webpage-client/src/components/subscriptions/CreditCardForm/submit.ts
+++ b/clients/packages/webpage-client/src/components/subscriptions/CreditCardForm/submit.ts
@@ -1,7 +1,7 @@
 import getConfig from 'next/config';
 import recharge from '../../../apis/rest/recharge';
 
-const { publicRuntimeConfig } = getConfig();
+const { serverRuntimeConfig } = getConfig();
 
 const submit = (values: any) => {
   //
@@ -17,7 +17,7 @@ const submit = (values: any) => {
   //
   const promise = new Promise((resolve, reject) => {
     // eslint-disable-next-line
-    (window as any).PagarMe.encryption_key = publicRuntimeConfig.pagarmeKey;
+    (window as any).PagarMe.encryption_key = serverRuntimeConfig.pagarmeKey;
 
     // eslint-disable-next-line
     const card = new (window as any).PagarMe.creditCard();

--- a/clients/packages/webpage-client/src/pages/api/campaigns/[widget_id].ts
+++ b/clients/packages/webpage-client/src/pages/api/campaigns/[widget_id].ts
@@ -8,12 +8,9 @@ interface Request {
 }
 
 const {
-    publicRuntimeConfig: {
-        openApiUrl,
-        openApiToken,
-        openApiCampaignId
-    }
-} = getConfig()
+    publicRuntimeConfig: { openApiUrl, openApiCampaignId },
+    serverRuntimeConfig: { openApiToken }
+} = getConfig();
 
 const campaign_id = openApiCampaignId;
 

--- a/clients/packages/webpage-client/src/pages/api/phone/[widget_id]/create.ts
+++ b/clients/packages/webpage-client/src/pages/api/phone/[widget_id]/create.ts
@@ -15,12 +15,9 @@ interface Request {
 }
 
 const {
-    publicRuntimeConfig: {
-        openApiUrl,
-        openApiToken,
-        openApiCampaignId
-    }
-} = getConfig()
+    publicRuntimeConfig: { openApiUrl, openApiCampaignId },
+    serverRuntimeConfig: { openApiToken }
+} = getConfig();
 
 const campaign_id = openApiCampaignId;
 

--- a/clients/packages/webpage-client/src/pages/api/phone/call/[call_id]/status.ts
+++ b/clients/packages/webpage-client/src/pages/api/phone/call/[call_id]/status.ts
@@ -8,11 +8,11 @@ interface Request {
 }
 
 const {
-    publicRuntimeConfig: {
-        openApiUrl,
+    publicRuntimeConfig: { openApiUrl },
+    serverRuntimeConfig: { 
         // openApiToken
     }
-} = getConfig()
+} = getConfig();
 
 export default async (req: Request, res: any) => {
     if (req.method === 'GET') {


### PR DESCRIPTION
## Contexto
Algumas chaves privadas estão sendo impressas no HTML que fica acessível para o usuário final.

Essas chaves do Pagarme, os Tokens da API GraphQL e do Open API deveriam ser secretas. É necessário revisar a forma de como resolver isso, entendendo ser uma função da própria tecnologia NextJS e então atualizar as chaves de acesso aos serviços.

https://nextjs.org/docs/pages/api-reference/next-config-js/runtime-configuration