### PR TITLE
feat(webpage): add phone field to pressure form

### DIFF
--- a/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
+++ b/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
@@ -147,7 +147,6 @@ const PressureForm = ({
                       </SelectField>
                     </WrapInputs>
                   )}
-                  {BeforeStandardFields && <MemoBeforeStandardFields />}
                   <WrapInputs>
                     <InputField
                       label={t('Pressure Name Label')}
@@ -164,6 +163,17 @@ const PressureForm = ({
                       validate={required(t('Pressure Blank Validation'))}
                     />
                   </WrapInputs>
+                  {BeforeStandardFields && <MemoBeforeStandardFields />}
+                  {showPhone && showPhone == 's' && (
+                    <WrapInputs>
+                      <InputField
+                        label={t('Pressure Phone Label')}
+                        name="phone"
+                        placeholder={t('Pressure Phone Placeholder')}
+                        validate={required(t('Pressure Blank Validation'))}
+                      />
+                    </WrapInputs>
+                  )}
                   {showState && showState === 's' && (
                     <WrapInputs>
                       <SelectField
@@ -208,16 +218,6 @@ const PressureForm = ({
                         label={t('Pressure City Label')}
                         name="city"
                         placeholder={t('Pressure City Placeholder')}
-                        validate={required(t('Pressure Blank Validation'))}
-                      />
-                    </WrapInputs>
-                  )}
-                  {showPhone && showPhone == 's' && (
-                    <WrapInputs>
-                      <InputField
-                        label={t('Pressure Phone Label')}
-                        name="phone"
-                        placeholder={t('Pressure Phone Placeholder')}
                         validate={required(t('Pressure Blank Validation'))}
                       />
                     </WrapInputs>

--- a/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
+++ b/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
@@ -154,6 +154,7 @@ const PressureForm = ({
                         label={t('Pressure Phone Label')}
                         name="phone"
                         placeholder={t('Pressure Phone Placeholder')}
+                        mask="+55 (99) 9 9999-9999"
                       />
                     </WrapInputs>
                   )}

--- a/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
+++ b/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
@@ -29,6 +29,7 @@ type Props = {
     settings: {
       main_color: string;
       show_city?: string;
+      show_phone?: string;
       button_text: string;
       pressure_subject?: string;
       pressure_body?: string;
@@ -67,6 +68,7 @@ const PressureForm = ({
     settings: {
       show_city: showCity,
       show_state: showState,
+      show_phone: showPhone,
       main_color: buttonColor,
       button_text: buttonText,
       is_subject_list: isSubjectList = 'n',
@@ -206,6 +208,16 @@ const PressureForm = ({
                         label={t('Pressure City Label')}
                         name="city"
                         placeholder={t('Pressure City Placeholder')}
+                        validate={required(t('Pressure Blank Validation'))}
+                      />
+                    </WrapInputs>
+                  )}
+                  {showPhone && showPhone == 's' && (
+                    <WrapInputs>
+                      <InputField
+                        label={t('Pressure Phone Label')}
+                        name="phone"
+                        placeholder={t('Pressure Phone Placeholder')}
                         validate={required(t('Pressure Blank Validation'))}
                       />
                     </WrapInputs>

--- a/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
+++ b/clients/packages/webpage-client/src/bonde-webpage/plugins/Pressure/components/Form/index.tsx
@@ -147,6 +147,16 @@ const PressureForm = ({
                       </SelectField>
                     </WrapInputs>
                   )}
+                  {BeforeStandardFields && <MemoBeforeStandardFields />}
+                  {showPhone && showPhone == 's' && (
+                    <WrapInputs>
+                      <InputField
+                        label={t('Pressure Phone Label')}
+                        name="phone"
+                        placeholder={t('Pressure Phone Placeholder')}
+                      />
+                    </WrapInputs>
+                  )}
                   <WrapInputs>
                     <InputField
                       label={t('Pressure Name Label')}
@@ -163,17 +173,6 @@ const PressureForm = ({
                       validate={required(t('Pressure Blank Validation'))}
                     />
                   </WrapInputs>
-                  {BeforeStandardFields && <MemoBeforeStandardFields />}
-                  {showPhone && showPhone == 's' && (
-                    <WrapInputs>
-                      <InputField
-                        label={t('Pressure Phone Label')}
-                        name="phone"
-                        placeholder={t('Pressure Phone Placeholder')}
-                        validate={required(t('Pressure Blank Validation'))}
-                      />
-                    </WrapInputs>
-                  )}
                   {showState && showState === 's' && (
                     <WrapInputs>
                       <SelectField

--- a/clients/packages/webpage-client/src/initialI18nStore/locales/pt-br.ts
+++ b/clients/packages/webpage-client/src/initialI18nStore/locales/pt-br.ts
@@ -21,6 +21,8 @@ export default {
   "Pressure City Label": "Cidade",
   "Pressure City Placeholder": "Insira sua cidade",
   "Pressure State Label": "Estado",
+  "Pressure Phone Label": "Whatsapp",
+  "Pressure Phone Placeholder": "(DDD) X XXXX-XXXX",
   "Pressure Email Label": "E-mail",
   "Pressure Email Placeholder": "Insira seu e-mail",
   "Pressure Subject Label": "Assunto",
@@ -32,5 +34,5 @@ export default {
   "Pressure Network Failed": "Houve um erro ao fazer a pressão",
   "Pressure TargetBlank Validation": "Ops, você precisa selecionar pelo menos um alvo para poder pressionar",
   "Political Filename": "politica-de-privacidade",
-  "Share Social Midia": "Compartilhar no {{app}}"
+  "Share Social Midia": "Compartilhar no {{app}}",
 }

--- a/clients/packages/webpage-client/src/initialI18nStore/locales/pt-br.ts
+++ b/clients/packages/webpage-client/src/initialI18nStore/locales/pt-br.ts
@@ -22,7 +22,7 @@ export default {
   "Pressure City Placeholder": "Insira sua cidade",
   "Pressure State Label": "Estado",
   "Pressure Phone Label": "Whatsapp",
-  "Pressure Phone Placeholder": "(DDD) X XXXX-XXXX",
+  "Pressure Phone Placeholder": "Insira seu número com DDD",
   "Pressure Email Label": "E-mail",
   "Pressure Email Placeholder": "Insira seu e-mail",
   "Pressure Subject Label": "Assunto",


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->

- Adiciona campo de telefone (whatsapp) a widgets de Pressão por E-mail
- Reordena campos de telefone e email
