### PR TITLE
feat(canary): add field to phone on pressure widget settings

### DIFF
--- a/clients/packages/canary-client/public/locales/pt-BR/widgetActions.json
+++ b/clients/packages/canary-client/public/locales/pt-BR/widgetActions.json
@@ -131,6 +131,13 @@
             "no": "Não"
           }
         },
+        "phone": {
+          "title": "Incluir campo de telefone?",
+          "radio": {
+            "yes": "Sim",
+            "no": "Não"
+          }
+        },
         "main_color": {
           "label": "Cor padrão",
           "tooltip": "Selecione a cor no box abaixo ou insira o valor em hex, por exemplo: #DC3DCE"

--- a/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Adjusts/index.tsx
+++ b/clients/packages/canary-client/src/scenes/WidgetActions/Settings/Adjusts/index.tsx
@@ -26,6 +26,7 @@ const AdjustsFields = ({ widget, updateCache }: any) => {
         settings: {
           show_city: "city-false",
           show_state: "n",
+          show_phone: "n",
           ...widget.settings
         }
       }}
@@ -70,6 +71,15 @@ const AdjustsFields = ({ widget, updateCache }: any) => {
                   >
                     <Radio value='city-true'>{t('settings.adjusts.fields.city.radio.yes')}</Radio>
                     <Radio value='city-false'>{t('settings.adjusts.fields.city.radio.no')}</Radio>
+                  </RadioField>
+
+                  <RadioField
+                    name='settings.show_phone'
+                    label={t('settings.adjusts.fields.phone.title')}
+                    columns="auto auto 1fr"
+                  >
+                    <Radio value='s'>{t('settings.adjusts.fields.phone.radio.yes')}</Radio>
+                    <Radio value='n'>{t('settings.adjusts.fields.phone.radio.no')}</Radio>
                   </RadioField>
                 </>
               )}


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->

- Adiciona configuração para habilitar campo de telefone na widget de Pressão por e-mail